### PR TITLE
Migrate to SwanLake Alpha5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha4/ballerina-linux-installer-x64-swan-lake-alpha4.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha4.deb
+  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha5/ballerina-linux-installer-x64-swan-lake-alpha5.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha5.deb
   - sudo apt-get install -f
   - bal --version
   - bal build --skip-tests

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "aws.s3"
-version = "0.99.3"
+version = "0.99.4"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["ballerina", "aws.s3", "amazon", "client", "connector"]

--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -1,17 +1,17 @@
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-alpha8"
+version = "2.0.0-alpha9"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-alpha7"
+version = "0.8.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
@@ -21,21 +21,21 @@ version = "0.0.0"
 [[dependency]]
 org = "ballerina"
 name = "regex"
-version = "0.7.0-alpha7"
+version = "0.7.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 

--- a/Package.md
+++ b/Package.md
@@ -23,7 +23,7 @@ Connector contains operations that create an object, delete an object, and retri
 ## Compatibility
 |                    |    Version                  |  
 |:------------------:|:---------------------------:|
-| Ballerina Language |   Swan Lake Alpha4          |
+| Ballerina Language |   Swan Lake Alpha5          |
 |   Amazon S3 API    |   2006-03-01                |
 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Connector contains operations that create an object, delete an object, and retri
 ## Compatibility
 | Ballerina Language Version | Amazon S3 API version  |
 | -------------------------- | ---------------------- |
-|     Swan Lake Alpha4       |       2006-03-01       |
+|     Swan Lake Alpha 5      |       2006-03-01       |
 
 
 ### Obtaining Access Keys


### PR DESCRIPTION
## Purpose
> Migrate the connector to Swan Lake Alpha 5: Resolves https://github.com/wso2-enterprise/choreo/issues/3774.

## Goals
> Migrate Amazon S3 connector to Swan Lake Alpha 5.