### PR TITLE
Change region as non required field

### DIFF
--- a/Package.md
+++ b/Package.md
@@ -43,6 +43,9 @@ You need to get credentials such as **Access Key** and **Secret Access Key (API 
 
 In the directory where you have your sample, create a `Config.toml` file and add the details you obtained above within the quotes. region, trustStorePath and trustStorePassword are optionals.
 
+**Note**
+By default, the bucket is created in the US East (N. Virginia) Region. You can optionally specify a Region in the configuration. You might choose a Region to optimize latency, minimize costs, or address regulatory requirements.
+
 **Ballerina Config.toml file**
 
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ You need to get credentials such as **Access Key** and **Secret Access Key (API 
 - To create a new secret access key for an IAM user, open the [IAM console](https://console.aws.amazon.com/iam/home?region=us-east-1#home). Click **Users** in the **Details** pane, click the appropriate IAM user, and then click **Create Access Key** on the **Security Credentials** tab.
 3. Download the newly created credentials, when prompted to do so in the key creation wizard.
 
+**Note**
+By default, the bucket is created in the US East (N. Virginia) Region. You can optionally specify a Region in the configuration. You might choose a Region to optimize latency, minimize costs, or address regulatory requirements.
+
 ## Running Tests
 
 1. Create `Config.toml` file in `module-ballerinax-aws.s3` with the following configurations and provide appropriate value.

--- a/client.bal
+++ b/client.bal
@@ -30,7 +30,7 @@ public client class Client {
     public http:Client amazonS3;
 
     public isolated function init(ClientConfiguration amazonS3Config) returns error? {
-        self.region = amazonS3Config.region;
+        self.region = (amazonS3Config?.region is string) ? <string>(amazonS3Config?.region) : DEFAULT_REGION;
         self.amazonHost = self.region != DEFAULT_REGION ? regex:replaceFirst(AMAZON_AWS_HOST, SERVICE_NAME,
             SERVICE_NAME + "." + self.region) :  AMAZON_AWS_HOST;
         string baseURL = HTTPS + self.amazonHost;
@@ -305,7 +305,7 @@ isolated function verifyCredentials(string accessKeyId, string secretAccessKey) 
 public type ClientConfiguration record {
     string accessKeyId;
     string secretAccessKey;
-    string region = DEFAULT_REGION;
+    string region?;
     http:ClientConfiguration clientConfig = {http1Settings: {chunking: http:CHUNKING_NEVER}};
     http:ClientSecureSocket secureSocketConfig?;
 };


### PR DESCRIPTION
## Purpose
Change region as non required field in the configuration.

## Goals
Fix https://github.com/wso2-enterprise/choreo/issues/4446

## Release note
By default, the bucket is created in the US East (N. Virginia) Region. You can optionally specify a Region in the request body. You might choose a Region to optimize latency, minimize costs, or address regulatory requirements. 

## Learning
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html
