### PR TITLE
Make release event type as published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Deployment
 
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2-enterprise/choreo/issues/7493

## Related PR
- We did the same fix in https://github.com/ballerina-platform/module-ballerinax-aws.sqs/pull/39

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- JDK 11
- Ballerina SL Beta 2
 
## Learning
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release