### PR TITLE
[SL Beta3] Handle large size file in `getObject` operation

### DIFF
--- a/s3/Dependencies.toml
+++ b/s3/Dependencies.toml
@@ -32,3 +32,8 @@ version = "2.0.0"
 org = "ballerina"
 name = "crypto"
 version = "2.0.0"
+
+[[dependency]]
+org = "ballerina"
+name = "io"
+version = "1.0.0"


### PR DESCRIPTION
## Purpose
Handle large size file in get object operation

## Goals
Fixes https://github.com/wso2-enterprise/choreo/issues/7935, https://github.com/wso2-enterprise/choreo/issues/3531

## Approach
Provide byte stream as return type instead of byte array. So user can iterate and get the whole file.

## Samples
Following snippet shows how to get an object as stream and store in a location.
``` ballerina
  stream<byte[], io:Error?> response = check amazonS3Client->getObject(testBucketName, fileName);
  error? e = response.forEach(isolated function(byte[] res) {
      error? r = io:fileWriteBytes("./resources/a.jpg", res, io:APPEND);
  });
```

## Test environment
SL Beta3
