### PR TITLE
Fix object retrieval for partial content

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -165,7 +165,7 @@ public isolated client class Client {
         check generateSignature(self.accessKeyId, self.secretAccessKey, self.region, GET, requestURI, UNSIGNED_PAYLOAD,
             requestHeaders);
         http:Response httpResponse = check self.amazonS3->get(requestURI, requestHeaders);
-        if (httpResponse.statusCode == http:STATUS_OK) {
+        if (httpResponse.statusCode == http:STATUS_OK || (httpResponse.statusCode == http:STATUS_PARTIAL_CONTENT && objectRetrievalHeaders?.range != ())) {
             if byteArraySize is int {
                 return httpResponse.getByteStream(byteArraySize);
             }


### PR DESCRIPTION
# Description

Modified the condition in the `getObject` function to consider both 200 OK and 206 Partial Content as successful responses. Currently, the library considers only a 200 OK status code as a successful response when retrieving objects. However, AWS S3 returns a 206 status code for partial content when byte range is specified in the objectRetrievalHeaders

Fixes #6007

One line release note: 
- Adds support for the 206 Partial Content status code when retrieving partial objects

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Executed a test case where a partial content request is made, expecting a 206 Partial Content response.
Verified that the library processes the 206 status code correctly and considers it a successful response.


**Test Configuration**:
* Ballerina Version: 2201.8.4
* Operating System: Ubuntu 22.04 LTS
* Java SDK:  11.0.21+9

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
