### PR TITLE
Add functions for creating AWS S3 Presigned URLs for GET and PUT requests

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -286,10 +286,9 @@ public isolated client class Client {
       
             // Replace '/' with '%2F' in the canonical query string.
         string:RegExp r = re `/`;
-
         canonicalQueryString = r.replaceAll(canonicalQueryString, "%2F");
 
-        string canonicalHeaders = "host:" + bucketName + "." + AMAZON_AWS_HOST;
+        string canonicalHeaders = "host:" + bucketName + ".s3." + self.region + ".amazonaws.com";
         string signedHeaders = "host";
         string canonicalRequest = string `${httpMethod}${"\n"}${canonicalURI}${"\n"}${canonicalQueryString}${"\n"}${canonicalHeaders}${"\n"}${"\n"}${signedHeaders}${"\n"}${UNSIGNED_PAYLOAD}`;
 
@@ -299,7 +298,7 @@ public isolated client class Client {
         string signature = check constructPresignSignature(self.accessKeyId, self.secretAccessKey, shortDateStr, self.region,
         signedHeaders, stringToSign);
 
-        string url = HTTPS + bucketName + "." + AMAZON_AWS_HOST + "/" + objectName + "?" + canonicalQueryString + "&X-Amz-Signature=" + signature;
+        string url = HTTPS +  bucketName + ".s3." + self.region + ".amazonaws.com" + "/" + objectName + "?" + canonicalQueryString + "&X-Amz-Signature=" + signature;
         return url;
     }
 }

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -256,6 +256,63 @@ public isolated client class Client {
         http:Response httpResponse = check self.amazonS3->delete(requestURI, request);
         return handleHttpResponse(httpResponse);
     }
+    
+    # Generates a presigned URL for the object.
+    #
+    # + bucketName - The name of the bucket
+    # + objectName - The name of the object
+    # + expirationTime - The time until the presigned URL is valid
+    # + httpMethod - The HTTP method to be used, either GET or PUT
+    # + return - If success, a presigned URL, else an error
+    @display {label: "Create Presigned URL"}
+    remote isolated function createPresignedURL(string bucketName, string objectName, string expirationTime, string httpMethod) returns string|error? {
+        string canonicalQueryString = "";
+        [string, string] [amzDateStr, shortDateStr] = ["", ""];
+        var result = generateDateString();
+        if (result is [string, string]) {
+            [amzDateStr, shortDateStr] = result;
+        } else {
+            return error("Error occurred while generating date string", result);
+        }
+
+        string canonicalURI = "/" + objectName;
+        map<string> queryParams = {
+            "X-Amz-Algorithm": AWS4_HMAC_SHA256,
+            "X-Amz-Content-Sha256": UNSIGNED_PAYLOAD,
+            "X-Amz-Credential": self.accessKeyId + "/" + shortDateStr + "/" + self.region + "/" + SERVICE_NAME + "/" + TERMINATION_STRING,
+            "X-Amz-Date": amzDateStr,
+            "X-Amz-Expires": expirationTime,
+            "X-Amz-SignedHeaders": "host"
+        };
+        if (canonicalURI is string) {
+            // Generate canonical query string.
+            if (queryParams is map<string> && queryParams.length() > 0) {
+                string|error canonicalQuery = generateCanonicalQueryString(queryParams);
+                if (canonicalQuery is string) {
+                    canonicalQueryString = canonicalQuery;
+                } else {
+                    return error(CANONICAL_QUERY_STRING_GENERATION_ERROR_MSG, canonicalQuery);
+                }
+            }
+            // Replace '/' with '%2F' in the canonical query string.
+            string:RegExp r = re `/`;
+
+            canonicalQueryString = r.replaceAll(canonicalQueryString, "%2F");
+
+            string canonicalHeaders = "host:" + bucketName + "." + AMAZON_AWS_HOST;
+            string signedHeaders = "host";
+            string canonicalRequest = string `${httpMethod}${"\n"}${canonicalURI}${"\n"}${canonicalQueryString}${"\n"}${canonicalHeaders}${"\n"}${"\n"}${signedHeaders}${"\n"}${UNSIGNED_PAYLOAD}`;
+
+            // Generate the string to sign
+            string stringToSign = generateStringToSign(amzDateStr, shortDateStr, self.region, canonicalRequest);
+
+            string signature = check constructPresignSignature(self.accessKeyId, self.secretAccessKey, shortDateStr, self.region,
+            signedHeaders, stringToSign);
+
+            string url = HTTPS + bucketName + "." + AMAZON_AWS_HOST + "/" + objectName + "?" + canonicalQueryString + "&X-Amz-Signature=" + signature;
+            return url;
+        }
+    }
 }
 
 isolated function setDefaultHeaders(string amazonHost) returns map<string> {

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -259,14 +259,16 @@ public isolated client class Client {
     
     # Generates a presigned URL for the object.
     #
-    # + bucketName - The name of the bucket
-    # + objectName - The name of the object
-    # + expirationTime - The time until the presigned URL is valid
-    # + httpMethod - The HTTP method to be used, either GET or PUT
+    # + bucketName - The name of the bucket  
+    # + objectName - The name of the object  
+    # + expirationTime - The time until the presigned URL is valid  
+    # + httpMethod - The HTTP method to be used, either GET or PUT  
+    # + partNo - The part number of the object, when uploading multipart objects
+    # + uploadId - The upload ID of the multipart upload
     # + return - If success, a presigned URL, else an error
     @display {label: "Create Presigned URL"}
-    remote isolated function createPresignedURL(string bucketName, string objectName, string expirationTime, string httpMethod) returns string|error? {
-        string canonicalQueryString = "";
+    remote isolated function createPresignedURL(string bucketName, string objectName, string expirationTime, string httpMethod, int partNo=0, string uploadId="") returns string|error? {
+
         [string, string] [amzDateStr, shortDateStr] = ["", ""];
         var result = generateDateString();
         if (result is [string, string]) {
@@ -276,42 +278,29 @@ public isolated client class Client {
         }
 
         string canonicalURI = "/" + objectName;
-        map<string> queryParams = {
-            "X-Amz-Algorithm": AWS4_HMAC_SHA256,
-            "X-Amz-Content-Sha256": UNSIGNED_PAYLOAD,
-            "X-Amz-Credential": self.accessKeyId + "/" + shortDateStr + "/" + self.region + "/" + SERVICE_NAME + "/" + TERMINATION_STRING,
-            "X-Amz-Date": amzDateStr,
-            "X-Amz-Expires": expirationTime,
-            "X-Amz-SignedHeaders": "host"
-        };
-        if (canonicalURI is string) {
-            // Generate canonical query string.
-            if (queryParams is map<string> && queryParams.length() > 0) {
-                string|error canonicalQuery = generateCanonicalQueryString(queryParams);
-                if (canonicalQuery is string) {
-                    canonicalQueryString = canonicalQuery;
-                } else {
-                    return error(CANONICAL_QUERY_STRING_GENERATION_ERROR_MSG, canonicalQuery);
-                }
-            }
-            // Replace '/' with '%2F' in the canonical query string.
-            string:RegExp r = re `/`;
-
-            canonicalQueryString = r.replaceAll(canonicalQueryString, "%2F");
-
-            string canonicalHeaders = "host:" + bucketName + "." + AMAZON_AWS_HOST;
-            string signedHeaders = "host";
-            string canonicalRequest = string `${httpMethod}${"\n"}${canonicalURI}${"\n"}${canonicalQueryString}${"\n"}${canonicalHeaders}${"\n"}${"\n"}${signedHeaders}${"\n"}${UNSIGNED_PAYLOAD}`;
-
-            // Generate the string to sign
-            string stringToSign = generateStringToSign(amzDateStr, shortDateStr, self.region, canonicalRequest);
-
-            string signature = check constructPresignSignature(self.accessKeyId, self.secretAccessKey, shortDateStr, self.region,
-            signedHeaders, stringToSign);
-
-            string url = HTTPS + bucketName + "." + AMAZON_AWS_HOST + "/" + objectName + "?" + canonicalQueryString + "&X-Amz-Signature=" + signature;
-            return url;
+     
+        string canonicalQueryString = "X-Amz-Algorithm=" + AWS4_HMAC_SHA256 + "&X-Amz-Content-Sha256=" + UNSIGNED_PAYLOAD + "&X-Amz-Credential=" + self.accessKeyId + "/" + shortDateStr + "/" + self.region + "/" + SERVICE_NAME + "/" + TERMINATION_STRING + "&X-Amz-Date=" + amzDateStr + "&X-Amz-Expires=" + expirationTime + "&X-Amz-SignedHeaders=host";
+        if (partNo != 0 && uploadId != "" && httpMethod == "PUT") {
+            canonicalQueryString = string `${canonicalQueryString}&partNumber=${partNo}&uploadId=${uploadId}`;
         }
+      
+            // Replace '/' with '%2F' in the canonical query string.
+        string:RegExp r = re `/`;
+
+        canonicalQueryString = r.replaceAll(canonicalQueryString, "%2F");
+
+        string canonicalHeaders = "host:" + bucketName + "." + AMAZON_AWS_HOST;
+        string signedHeaders = "host";
+        string canonicalRequest = string `${httpMethod}${"\n"}${canonicalURI}${"\n"}${canonicalQueryString}${"\n"}${canonicalHeaders}${"\n"}${"\n"}${signedHeaders}${"\n"}${UNSIGNED_PAYLOAD}`;
+
+        // Generate the string to sign
+        string stringToSign = generateStringToSign(amzDateStr, shortDateStr, self.region, canonicalRequest);
+
+        string signature = check constructPresignSignature(self.accessKeyId, self.secretAccessKey, shortDateStr, self.region,
+        signedHeaders, stringToSign);
+
+        string url = HTTPS + bucketName + "." + AMAZON_AWS_HOST + "/" + objectName + "?" + canonicalQueryString + "&X-Amz-Signature=" + signature;
+        return url;
     }
 }
 

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -276,15 +276,31 @@ public isolated client class Client {
         } else {
             return error("Error occurred while generating date string", result);
         }
+        map<string> queryParams = {
+            ["X-Amz-Algorithm"]: AWS4_HMAC_SHA256,
+            ["X-Amz-Credential"]: self.accessKeyId + "/" + shortDateStr + "/" + self.region + "/" + SERVICE_NAME + "/" + TERMINATION_STRING,
+            ["X-Amz-Date"]: amzDateStr,
+            ["X-Amz-Expires"]: expirationTime,
+            ["X-Amz-SignedHeaders"]: "host"
+        };
 
         string canonicalURI = "/" + objectName;
-     
-        string canonicalQueryString = "X-Amz-Algorithm=" + AWS4_HMAC_SHA256 + "&X-Amz-Content-Sha256=" + UNSIGNED_PAYLOAD + "&X-Amz-Credential=" + self.accessKeyId + "/" + shortDateStr + "/" + self.region + "/" + SERVICE_NAME + "/" + TERMINATION_STRING + "&X-Amz-Date=" + amzDateStr + "&X-Amz-Expires=" + expirationTime + "&X-Amz-SignedHeaders=host";
+        string canonicalQueryString=EMPTY_STRING;
+        
+        if (queryParams is map<string> && queryParams.length() > 0) {
+            string|error canonicalQuery = generateCanonicalQueryString(queryParams);
+            if (canonicalQuery is string) {
+                canonicalQueryString = canonicalQuery;
+            } else {
+                return error(CANONICAL_QUERY_STRING_GENERATION_ERROR_MSG, canonicalQuery);
+            }
+        }
+
         if (partNo != 0 && uploadId != "" && httpMethod == "PUT") {
             canonicalQueryString = string `${canonicalQueryString}&partNumber=${partNo}&uploadId=${uploadId}`;
         }
-      
-            // Replace '/' with '%2F' in the canonical query string.
+
+        // Replace '/' with '%2F' in the canonical query string.
         string:RegExp r = re `/`;
         canonicalQueryString = r.replaceAll(canonicalQueryString, "%2F");
 
@@ -299,6 +315,7 @@ public isolated client class Client {
         signedHeaders, stringToSign);
 
         string url = HTTPS +  bucketName + ".s3." + self.region + ".amazonaws.com" + "/" + objectName + "?" + canonicalQueryString + "&X-Amz-Signature=" + signature;
+        
         return url;
     }
 }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -19,6 +19,7 @@
 import ballerina/io;
 import ballerina/log;
 import ballerina/test;
+import ballerina/http;
 import ballerina/os;
 
 configurable string testBucketName = os:getEnv("BUCKET_NAME");
@@ -83,6 +84,28 @@ function testCreateObject() {
         test:assertFail(amazonS3Client.toString());
     }
 }
+@test:Config {
+    dependsOn: [testGetObject]
+}
+function testCreatePresignedURLGET() returns error? {
+    log:printInfo("amazonS3Client->createPresignedURLGET()");
+    Client|error amazonS3Client = new(amazonS3Config);
+    if (amazonS3Client is Client) {
+        string|error? response = amazonS3Client->createPresignedURL(testBucketName, fileName,"3600","GET");
+        if (response is error) {
+            test:assertFail(response.toString());
+        } else if (response is string) {
+            io:println(response);
+            http:Client cl = check new(response);
+            http:Response a = check cl->get("");
+            io:println(a.getTextPayload());
+            test:assertEquals(a.statusCode, 200, "Failed to create presigned URL");
+        } else {
+            test:assertFail();
+        }
+    }
+}
+
 
 @test:Config {
     dependsOn: [testCreateObject]

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -95,10 +95,27 @@ function testCreatePresignedURLGET() returns error? {
         if (response is error) {
             test:assertFail(response.toString());
         } else if (response is string) {
-            io:println(response);
             http:Client cl = check new(response);
             http:Response a = check cl->get("");
-            io:println(a.getTextPayload());
+            test:assertEquals(a.statusCode, 200, "Failed to create presigned URL");
+        } else {
+            test:assertFail();
+        }
+    }
+}
+@test:Config {
+    dependsOn: [testGetObject]
+}
+function testCreatePresignedURLPUT() returns error? {
+    log:printInfo("amazonS3Client->createPresignedURLPUT()");
+    Client|error amazonS3Client = new(amazonS3Config);
+    if (amazonS3Client is Client) {
+        string|error? response = amazonS3Client->createPresignedURL(testBucketName, fileName,"3600","PUT");
+        if (response is error) {
+            test:assertFail(response.toString());
+        } else if (response is string) {
+            http:Client cl = check new(response);
+            http:Response a = check cl->put("", content);
             test:assertEquals(a.statusCode, 200, "Failed to create presigned URL");
         } else {
             test:assertFail();

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -188,6 +188,20 @@ isolated function generateCanonicalHeaders(map<string> headers, http:Request? re
     return [canonicalHeaders, signedHeaders];
 }
 
+# Function to generate signing key.
+#
+# + secretAccessKey - Value of the secret key.
+# + shortDateStr - shortDateStr Parameter Description
+# + region - Endpoint region.
+# + return - Signing key.
+isolated function generateSigningKey(string secretAccessKey, string shortDateStr, string region) returns byte[]|error {
+    string signValue = AWS4 + secretAccessKey;
+    byte[] dateKey = check crypto:hmacSha256(shortDateStr.toBytes(), signValue.toBytes());
+    byte[] regionKey = check crypto:hmacSha256(region.toBytes(), dateKey);
+    byte[] serviceKey = check crypto:hmacSha256(SERVICE_NAME.toBytes(), regionKey);
+    return check crypto:hmacSha256(TERMINATION_STRING.toBytes(), serviceKey);
+}
+
 # Funtion to construct authorization header string.
 #
 # + accessKeyId - Value of the access key.
@@ -198,19 +212,30 @@ isolated function generateCanonicalHeaders(map<string> headers, http:Request? re
 # + stringToSign - stringToSign Parameter Description
 # + return - Authorization header string value.
 isolated function constructAuthSignature(string accessKeyId, string secretAccessKey, string shortDateStr, string region,
-                                string signedHeaders, string stringToSign) returns string|error {
-    string signValue = AWS4 + secretAccessKey;
-    byte[] dateKey =  check crypto:hmacSha256(shortDateStr.toBytes(), signValue.toBytes());
-    byte[] regionKey = check crypto:hmacSha256(region.toBytes(), dateKey);
-    byte[] serviceKey = check crypto:hmacSha256(SERVICE_NAME.toBytes(), regionKey);
-    byte[] signingKey = check  crypto:hmacSha256(TERMINATION_STRING.toBytes(), serviceKey);
+        string signedHeaders, string stringToSign) returns string|error {
 
-    string encodedStr = array:toBase16(check  crypto:hmacSha256(stringToSign.toBytes(), signingKey));
+    byte[] signingKey = check generateSigningKey(secretAccessKey, shortDateStr, region);
+    string encodedStr = array:toBase16(check crypto:hmacSha256(stringToSign.toBytes(), signingKey));
     string credential = string `${accessKeyId}/${shortDateStr}/${region}/${SERVICE_NAME}/${TERMINATION_STRING}`;
     string authHeader = string `${AWS4_HMAC_SHA256} ${CREDENTIAL}=${credential},${SIGNED_HEADER}=${signedHeaders}`;
     authHeader = string `${authHeader},${SIGNATURE}=${encodedStr.toLowerAscii()}`;
-
     return authHeader;
+}
+
+# Function to construct signature for presigned URLs
+#
+# + accessKeyId - Value of the access key.
+# + secretAccessKey - Value of the secret key.
+# + shortDateStr - shortDateStr Parameter Description  
+# + region - Endpoint region.
+# + signedHeaders - Signed headers.
+# + stringToSign - stringToSign Parameter Description
+# + return - Signature for presigned URLs.
+isolated function constructPresignSignature(string accessKeyId, string secretAccessKey, string shortDateStr, string region,
+        string signedHeaders, string stringToSign) returns string|error {
+    byte[] signingKey = check generateSigningKey(secretAccessKey, shortDateStr, region);
+    string encodedStr = array:toBase16(check crypto:hmacSha256(stringToSign.toBytes(), signingKey));
+    return encodedStr.toLowerAscii();
 }
 
 # Function to populate createObject optional headers.


### PR DESCRIPTION
# Description

`createPresignedURL` Function has been added to generate presigned URLs that can be used to upload and download files from Amazon S3 buckets.

Learning : https://docs.aws.amazon.com/AmazonS3/latest/userguide/example_s3_Scenario_PresignedUrl_section.html

Fixes [issue](https://github.com/ballerina-platform/ballerina-library/issues/6114)

One line release note: 
- Added functions to generate presigned URLs 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Created test functions

**Test Configuration**:
* Ballerina Version: Ballerina 2201.8.5 (Swan Lake Update 8)
* Operating System: Ubuntu 22.04.4 LTS
* Java SDK: openjdk 17.0.10 2024-01-16

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
