### PR TITLE
Add content-type property to ObjectCreationHeaders

### DIFF
--- a/ballerina/records.bal
+++ b/ballerina/records.bal
@@ -108,6 +108,7 @@ public type ObjectRetrievalHeaders record {
 # + contentMD5 - The base64-encoded 128-bit MD5 digest of the message (without the headers)
 # + expect - When your application uses 100-continue, it does not send the request body until it receives an acknowledgment.The date and time at which the object is no longer able to be cached
 # + expires - The date and time at which the object is no longer cacheable
+# + contentType - The MIME type of the content
 public type ObjectCreationHeaders record {
     @display {label: "Cache Control"}
     string cacheControl?;
@@ -123,4 +124,6 @@ public type ObjectCreationHeaders record {
     string expect?;
     @display {label: "Expiry Time"}
     string expires?;
+    @display {label: "Content Type"}
+    string contentType?;
 };

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -241,6 +241,9 @@ isolated function populateCreateObjectHeaders(map<string> requestHeaders, Object
         if (objectCreationHeaders?.expires != ()) {
             requestHeaders[EXPIRES] = <string>objectCreationHeaders?.expires;
         }
+        if (objectCreationHeaders?.contentType != ()) {
+            requestHeaders[CONTENT_TYPE] = <string>objectCreationHeaders?.contentType;
+        }
     }
 }
 


### PR DESCRIPTION
# Description

The Content-Type header is a common header for [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html). This PR is created to assign the missing Content-Type property to ObjectCreationHeaders.