### PR TITLE
[2201.4.x] Backport user-defined metadata and content-type header support

### DIFF
--- a/s3/Ballerina.toml
+++ b/s3/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.4.1"
 org = "ballerinax"
 name = "aws.s3"
-version = "3.2.1"
+version = "3.3.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Amazon"]

--- a/s3/Dependencies.toml
+++ b/s3/Dependencies.toml
@@ -319,7 +319,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "aws.s3"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/s3/client.bal
+++ b/s3/client.bal
@@ -176,13 +176,14 @@ public isolated client class Client {
         }
     }
 
-    # Creates an object.
+    # Creates an object. 
     #
     # + bucketName - The name of the bucket
     # + objectName - The name of the object
     # + payload - The file content that needed to be added to the bucket
     # + cannedACL - The access control list of the new object
     # + objectCreationHeaders - Optional headers for the `createObject` function
+    # + userMetadataHeaders - Optional headers to add user defined meta data
     # + return - An error on failure or else `()`
     @display {label: "Create Object"}
     remote isolated function createObject(@display {label: "Bucket Name"} string bucketName,
@@ -190,7 +191,9 @@ public isolated client class Client {
                                     @display {label: "File Content"} string|xml|json|byte[]|stream<io:Block, io:Error?> payload,
                                     @display {label: "Grant"} CannedACL? cannedACL = (),
                                     @display {label: "Object Creation Headers"} ObjectCreationHeaders?
-                                    objectCreationHeaders = ()) returns @tainted error? {
+                                    objectCreationHeaders = (), 
+                                    @display {label: "User Metadata Headers"} map<string> userMetadataHeaders = {}
+                                    ) returns @tainted error? {
         http:Request request = new;
         string requestURI = string `/${bucketName}/${objectName}`;
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
@@ -204,6 +207,9 @@ public isolated client class Client {
         
         // Add optional headers.
         populateCreateObjectHeaders(requestHeaders, objectCreationHeaders);
+
+        //Add user defined metadata headers
+        populateUserMetadataHeaders(requestHeaders, userMetadataHeaders);
         
         check generateSignature(self.accessKeyId, self.secretAccessKey, self.region, PUT, requestURI, UNSIGNED_PAYLOAD,
             requestHeaders, request);

--- a/s3/client.bal
+++ b/s3/client.bal
@@ -176,24 +176,23 @@ public isolated client class Client {
         }
     }
 
-    # Creates an object. 
+    # Creates an object.
     #
     # + bucketName - The name of the bucket
     # + objectName - The name of the object
     # + payload - The file content that needed to be added to the bucket
     # + cannedACL - The access control list of the new object
     # + objectCreationHeaders - Optional headers for the `createObject` function
-    # + userMetadataHeaders - Optional headers to add user defined meta data
+    # + userMetadataHeaders - Optional headers to add user-defined metadata
     # + return - An error on failure or else `()`
     @display {label: "Create Object"}
     remote isolated function createObject(@display {label: "Bucket Name"} string bucketName,
                                     @display {label: "Object Name"} string objectName,
                                     @display {label: "File Content"} string|xml|json|byte[]|stream<io:Block, io:Error?> payload,
                                     @display {label: "Grant"} CannedACL? cannedACL = (),
-                                    @display {label: "Object Creation Headers"} ObjectCreationHeaders?
-                                    objectCreationHeaders = (), 
-                                    @display {label: "User Metadata Headers"} map<string> userMetadataHeaders = {}
-                                    ) returns @tainted error? {
+                                    @display {label: "Object Creation Headers"} ObjectCreationHeaders? objectCreationHeaders = (), 
+                                    @display {label: "User Metadata Headers"} map<string> userMetadataHeaders = {}) 
+                                    returns error? {
         http:Request request = new;
         string requestURI = string `/${bucketName}/${objectName}`;
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
@@ -208,7 +207,7 @@ public isolated client class Client {
         // Add optional headers.
         populateCreateObjectHeaders(requestHeaders, objectCreationHeaders);
 
-        //Add user defined metadata headers
+        // Add user-defined metadata headers.
         populateUserMetadataHeaders(requestHeaders, userMetadataHeaders);
         
         check generateSignature(self.accessKeyId, self.secretAccessKey, self.region, PUT, requestURI, UNSIGNED_PAYLOAD,

--- a/s3/records.bal
+++ b/s3/records.bal
@@ -108,6 +108,7 @@ public type ObjectRetrievalHeaders record {
 # + contentMD5 - The base64-encoded 128-bit MD5 digest of the message (without the headers)
 # + expect - When your application uses 100-continue, it does not send the request body until it receives an acknowledgment.The date and time at which the object is no longer able to be cached
 # + expires - The date and time at which the object is no longer cacheable
+# + contentType - The MIME type of the content
 public type ObjectCreationHeaders record {
     @display {label: "Cache Control"}
     string cacheControl?;
@@ -123,4 +124,6 @@ public type ObjectCreationHeaders record {
     string expect?;
     @display {label: "Expiry Time"}
     string expires?;
+    @display {label: "Content Type"}
+    string contentType?;
 };

--- a/s3/tests/test.bal
+++ b/s3/tests/test.bal
@@ -87,21 +87,14 @@ function testCreateObject() {
 @test:Config {
     dependsOn: [testCreateBucket]
 }
-function testCreateObjectWithMetadata() {
-    log:printInfo("amazonS3Client->createObject()");
+function testCreateObjectWithMetadata() returns error? {
     map<string> metadata = {
         "Description" : "This is a text file",
         "Language" : "English"
     };
-    Client|error amazonS3Client = new(amazonS3Config);
-    if (amazonS3Client is Client) {
-        error? response = amazonS3Client->createObject(testBucketName, fileName, content, userMetadataHeaders = metadata);
-        if (response is error) {
-            test:assertFail(response.toString());
-        }
-    } else {
-        test:assertFail(amazonS3Client.toString());
-    }
+    
+    Client amazonS3Client = check new(amazonS3Config);
+    _ = check amazonS3Client->createObject(testBucketName, fileName, content, userMetadataHeaders = metadata);
 }
 
 @test:Config {

--- a/s3/tests/test.bal
+++ b/s3/tests/test.bal
@@ -85,6 +85,26 @@ function testCreateObject() {
 }
 
 @test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testCreateObjectWithMetadata() {
+    log:printInfo("amazonS3Client->createObject()");
+    map<string> metadata = {
+        "Description" : "This is a text file",
+        "Language" : "English"
+    };
+    Client|error amazonS3Client = new(amazonS3Config);
+    if (amazonS3Client is Client) {
+        error? response = amazonS3Client->createObject(testBucketName, fileName, content, userMetadataHeaders = metadata);
+        if (response is error) {
+            test:assertFail(response.toString());
+        }
+    } else {
+        test:assertFail(amazonS3Client.toString());
+    }
+}
+
+@test:Config {
     dependsOn: [testCreateObject]
 }
 function testGetObject() returns error? {

--- a/s3/utils.bal
+++ b/s3/utils.bal
@@ -253,7 +253,7 @@ isolated function populateCreateObjectHeaders(map<string> requestHeaders, Object
 # + userMetadataHeaders - Map containing user-defined metadata.
 isolated function populateUserMetadataHeaders(map<string> requestHeaders, map<string> userMetadataHeaders){
     foreach string metadataKey in userMetadataHeaders.keys() {
-        requestHeaders["x-amz-meta-" + metadataKey.toLowerAscii()] = userMetadataHeaders[metadataKey] ?: "";
+        requestHeaders[string `x-amz-meta-${metadataKey.toLowerAscii()}`] = userMetadataHeaders.get(metadataKey);
     }
 }
 

--- a/s3/utils.bal
+++ b/s3/utils.bal
@@ -244,6 +244,18 @@ isolated function populateCreateObjectHeaders(map<string> requestHeaders, Object
     }
 }
 
+# Function to populate createObject optional user-defined metadata headers.
+#
+# + requestHeaders - Request headers map.
+# + userMetadataHeaders - Map containing user-defined metadata.
+isolated function populateUserMetadataHeaders(map<string> requestHeaders, map<string> userMetadataHeaders){
+    if(userMetadataHeaders.length() != 0) {
+        foreach string metadataKey in userMetadataHeaders.keys() {
+            requestHeaders["x-amz-meta-" + metadataKey.toLowerAscii()] = <string>userMetadataHeaders[metadataKey];
+        }
+    }
+}
+
 # Function to populate getObject optional headers.
 #
 # + requestHeaders - Request headers map.

--- a/s3/utils.bal
+++ b/s3/utils.bal
@@ -241,6 +241,9 @@ isolated function populateCreateObjectHeaders(map<string> requestHeaders, Object
         if (objectCreationHeaders?.expires != ()) {
             requestHeaders[EXPIRES] = <string>objectCreationHeaders?.expires;
         }
+        if (objectCreationHeaders?.contentType != ()) {
+            requestHeaders[CONTENT_TYPE] = <string>objectCreationHeaders?.contentType;
+        }
     }
 }
 

--- a/s3/utils.bal
+++ b/s3/utils.bal
@@ -250,7 +250,7 @@ isolated function populateCreateObjectHeaders(map<string> requestHeaders, Object
 # + userMetadataHeaders - Map containing user-defined metadata.
 isolated function populateUserMetadataHeaders(map<string> requestHeaders, map<string> userMetadataHeaders){
     foreach string metadataKey in userMetadataHeaders.keys() {
-        requestHeaders["x-amz-meta-" + metadataKey.toLowerAscii()] = <string>userMetadataHeaders[metadataKey];
+        requestHeaders["x-amz-meta-" + metadataKey.toLowerAscii()] = userMetadataHeaders[metadataKey] ?: "";
     }
 }
 

--- a/s3/utils.bal
+++ b/s3/utils.bal
@@ -249,10 +249,8 @@ isolated function populateCreateObjectHeaders(map<string> requestHeaders, Object
 # + requestHeaders - Request headers map.
 # + userMetadataHeaders - Map containing user-defined metadata.
 isolated function populateUserMetadataHeaders(map<string> requestHeaders, map<string> userMetadataHeaders){
-    if(userMetadataHeaders.length() != 0) {
-        foreach string metadataKey in userMetadataHeaders.keys() {
-            requestHeaders["x-amz-meta-" + metadataKey.toLowerAscii()] = <string>userMetadataHeaders[metadataKey];
-        }
+    foreach string metadataKey in userMetadataHeaders.keys() {
+        requestHeaders["x-amz-meta-" + metadataKey.toLowerAscii()] = <string>userMetadataHeaders[metadataKey];
     }
 }
 


### PR DESCRIPTION
# Description
This PR backports the improvements (added to the master branch) with  https://github.com/ballerina-platform/module-ballerinax-aws.s3/pull/109 and https://github.com/ballerina-platform/module-ballerinax-aws.s3/pull/110

Related Pull Requests (remove if not relevant)
- https://github.com/ballerina-platform/module-ballerinax-aws.s3/pull/109
- https://github.com/ballerina-platform/module-ballerinax-aws.s3/pull/110

One line release note: 
- One line describing the feature/improvement/fix made by this PR 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
