### PR TITLE
Add MultipartUpload functions

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -395,7 +395,7 @@ public isolated client class Client {
     # + partNumber - The part number of the object  
     # + uploadPartHeaders - Optional headers for the upload
     # + return - An error on failure or else `()`
-    remote isolated function UploadPart(
+    remote isolated function uploadPart(
             @display {label: "Object Name"} string objectName,
             @display {label: "Bucket Name"} string bucketName,
             @display {label: "File Content"} string|xml|json|byte[]|stream<io:Block, io:Error?> payload,

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -353,8 +353,8 @@ public isolated client class Client {
             @display {label: "Object Name"} string objectName,
             @display {label: "Bucket Name"} string bucketName,
             @display {label: "Grant"} CannedACL? cannedACL = (),
-            @display {label: "Multipart Upload Headers"} MultipartUploadHeaders? multipartUploadHeaders = ()
-            ) returns string|error {
+            @display {label: "Multipart Upload Headers"} MultipartUploadHeaders? multipartUploadHeaders = ())
+            returns string|error {
 
         if objectName == EMPTY_STRING {
             return error(EMPTY_OBJECT_NAME_ERROR_MSG);
@@ -401,8 +401,8 @@ public isolated client class Client {
             @display {label: "File Content"} string|xml|json|byte[]|stream<io:Block, io:Error?> payload,
             @display {label: "Upload ID"} string uploadId,
             @display {label: "Part Number"} int partNumber,
-            @display {label: "UploadPartHeaders"} UploadPartHeaders? uploadPartHeaders = ()
-        ) returns CompletedPart|error {
+            @display {label: "UploadPartHeaders"} UploadPartHeaders? uploadPartHeaders = ())
+            returns CompletedPart|error {
 
         if objectName == EMPTY_STRING {
             return error(EMPTY_OBJECT_NAME_ERROR_MSG);
@@ -457,8 +457,8 @@ public isolated client class Client {
             @display {label: "Object Name"} string objectName,
             @display {label: "Bucket Name"} string bucketName,
             @display {label: "Upload ID"} string uploadId,
-            @display {label: "Array of Parts"} CompletedPart[] CompletedParts
-            ) returns error? {
+            @display {label: "Array of Parts"} CompletedPart[] CompletedParts)
+            returns error? {
         
         if objectName == EMPTY_STRING {
             return error(EMPTY_OBJECT_NAME_ERROR_MSG);
@@ -481,7 +481,7 @@ public isolated client class Client {
         requestURI = string `${requestURI}${queryParamStr}`;
 
         string payload = string `<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`;
-        foreach var part in CompletedParts {
+        foreach CompletedPart part in CompletedParts {
             payload = string `${payload}<Part><PartNumber>${part.partNumber.toString()}</PartNumber><ETag>${part.ETag}</ETag></Part>`;
         }
         payload = string `${payload}</CompleteMultipartUpload>`;
@@ -500,8 +500,8 @@ public isolated client class Client {
     remote isolated function abortMultipartUpload(
             @display {label: "Object Name"} string objectName,
             @display {label: "Bucket Name"} string bucketName,
-            @display {label: "Upload ID"} string uploadId            
-        ) returns @tainted error? {
+            @display {label: "Upload ID"} string uploadId)
+            returns error? {
         
         if objectName == EMPTY_STRING {
             return error(EMPTY_OBJECT_NAME_ERROR_MSG);

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -457,7 +457,7 @@ public isolated client class Client {
             @display {label: "Object Name"} string objectName,
             @display {label: "Bucket Name"} string bucketName,
             @display {label: "Upload ID"} string uploadId,
-            @display {label: "Array of Parts"} CompletedPart[] CompletedParts)
+            @display {label: "Completed Parts"} CompletedPart[] completedParts)
             returns error? {
         
         if objectName == EMPTY_STRING {
@@ -481,7 +481,7 @@ public isolated client class Client {
         requestURI = string `${requestURI}${queryParamStr}`;
 
         string payload = string `<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`;
-        foreach CompletedPart part in CompletedParts {
+        foreach CompletedPart part in completedParts {
             payload = string `${payload}<Part><PartNumber>${part.partNumber.toString()}</PartNumber><ETag>${part.ETag}</ETag></Part>`;
         }
         payload = string `${payload}</CompleteMultipartUpload>`;

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -414,11 +414,6 @@ public isolated client class Client {
 
         string requestURI = string `/${bucketName}/${objectName}`;
         string queryParamStr = string `?partNumber=${partNumber}&uploadId=${uploadId}`;
-        
-        map<string> queryParamsMap = {
-            "partNumber": partNumber.toString(),
-            "uploadId": uploadId
-        };
 
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
 
@@ -431,9 +426,9 @@ public isolated client class Client {
         } else {
             request.setPayload(payload);
         }
-
+        
         check generateSignature(self.accessKeyId, self.secretAccessKey, self.region, PUT, requestURI, UNSIGNED_PAYLOAD,
-            requestHeaders, request, queryParams = queryParamsMap);
+            requestHeaders, request, queryParams = {"partNumber": partNumber.toString(), "uploadId": uploadId});
         requestURI = string `${requestURI}${queryParamStr}`;
 
         http:Response httpResponse = check self.amazonS3->put(requestURI, request);
@@ -449,9 +444,9 @@ public isolated client class Client {
     # Completes a multipart upload by assembling previously uploaded parts.
     #
     # + objectName - The name of the object  
-    # + bucketName - The name of the bucket
+    # + bucketName - The name of the bucket  
     # + uploadId - The upload ID of the multipart upload  
-    # + CompletedParts - An array containing the part number and ETag of each uploaded part
+    # + completedParts - An array containing the part number and ETag of each uploaded part
     # + return - An error on failure or else `()`
     remote isolated function completeMultipartUpload(
             @display {label: "Object Name"} string objectName,
@@ -471,13 +466,11 @@ public isolated client class Client {
 
         string requestURI = string `/${bucketName}/${objectName}`;
         string queryParamStr = string `?uploadId=${uploadId}`;
-        map<string> queryParamsMap = {
-            "uploadId": uploadId
-        };
+
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
 
         check generateSignature(self.accessKeyId, self.secretAccessKey, self.region, POST, requestURI, 
-            UNSIGNED_PAYLOAD, requestHeaders, request, queryParams = queryParamsMap);
+            UNSIGNED_PAYLOAD, requestHeaders, request, queryParams = {"uploadId": uploadId});
         requestURI = string `${requestURI}${queryParamStr}`;
 
         string payload = string `<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`;
@@ -510,19 +503,15 @@ public isolated client class Client {
             return error(EMPTY_BUCKET_NAME_ERROR_MSG);
         }
 
-        map<string> queryParamsMap = {
-            "uploadId": uploadId
-        };
-
-        string queryParamStr = string `?uploadId=${uploadId}`;
         http:Request request = new;
 
         string requestURI = string `/${bucketName}/${objectName}`;
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
 
         check generateSignature(self.accessKeyId, self.secretAccessKey, self.region, DELETE, requestURI, 
-            UNSIGNED_PAYLOAD, requestHeaders, request, queryParams = queryParamsMap);
-        requestURI = string `${requestURI}${queryParamStr}`;
+            UNSIGNED_PAYLOAD, requestHeaders, request, queryParams = {"uploadId": uploadId});
+        
+        requestURI = string `${requestURI}?uploadId=${uploadId}`;
 
         http:Response httpResponse = check self.amazonS3->delete(requestURI, request);
         return handleHttpResponse(httpResponse);

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -401,7 +401,7 @@ public isolated client class Client {
             @display {label: "File Content"} string|xml|json|byte[]|stream<io:Block, io:Error?> payload,
             @display {label: "Upload ID"} string uploadId,
             @display {label: "Part Number"} int partNumber,
-            @display {label: "UploadPartHeaders"} UploadPartHeaders? uploadPartHeaders = ())
+            @display {label: "UploadPart Headers"} UploadPartHeaders? uploadPartHeaders = ())
             returns CompletedPart|error {
 
         if objectName == EMPTY_STRING {

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -368,8 +368,8 @@ public isolated client class Client {
         string requestURI = string `/${bucketName}/${objectName}`;
         string queryParamStr = string `?uploads`;
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
-        if cannedACL != () {
-            requestHeaders[X_AMZ_ACL] = cannedACL.toString();
+        if cannedACL is CannedACL {
+            requestHeaders[X_AMZ_ACL] = cannedACL;
         }
         populateMultipartUploadHeaders(requestHeaders, multipartUploadHeaders);
 
@@ -422,9 +422,7 @@ public isolated client class Client {
 
         map<string> requestHeaders = setDefaultHeaders(self.amazonHost);
 
-        if uploadPartHeaders != () {
-            populateUploadPartHeaders(requestHeaders, uploadPartHeaders);
-        }
+        populateUploadPartHeaders(requestHeaders, uploadPartHeaders);
 
         if payload is byte[] {
             request.setBinaryPayload(payload);
@@ -460,7 +458,7 @@ public isolated client class Client {
             @display {label: "Bucket Name"} string bucketName,
             @display {label: "Upload ID"} string uploadId,
             @display {label: "Array of Parts"} CompletedPart[] CompletedParts
-            ) returns @tainted error? {
+            ) returns error? {
         
         if objectName == EMPTY_STRING {
             return error(EMPTY_OBJECT_NAME_ERROR_MSG);

--- a/ballerina/constants.bal
+++ b/ballerina/constants.bal
@@ -60,6 +60,7 @@ const X_AMZ_SIGNATURE = "X-Amz-Signature";
 // HTTP verbs.
 const string GET = "GET";
 const string PUT = "PUT";
+const POST = "POST";
 const string DELETE = "DELETE";
 const string TRUE = "TRUE";
 const string FALSE = "FALSE";

--- a/ballerina/data_mappings.bal
+++ b/ballerina/data_mappings.bal
@@ -51,3 +51,7 @@ isolated function getS3ObjectsList(xml response) returns S3Object[] {
     }
     return s3Objects;
 }
+
+isolated function getUploadId(xml response) returns string {
+    return (response/<UploadId>/*).toString();
+}

--- a/ballerina/records.bal
+++ b/ballerina/records.bal
@@ -128,7 +128,7 @@ public type ObjectCreationHeaders record {
     string contentType?;
 };
 
-# Represents the optional headers specific to CreateMultipartUpload function. 
+# Represents the optional headers specific to `CreateMultipartUpload` function. 
 #
 # + cacheControl - Can be used to specify caching behavior along the request/reply chain
 # + contentDisposition - Specifies presentational information for the object
@@ -152,17 +152,19 @@ public type MultipartUploadHeaders record {
     string expires?;
 };
 
-# Represents the details of a part uploaded through the UploadPart function.
+# Represents the details of a part uploaded through the `UploadPart` function.
 #
 # + partNumber - The part number of the file part
 # + ETag - The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, 
 #          not its metadata
 public type CompletedPart record {
+    @display {label: "Part Number"}
     int partNumber;
+    @display {label: "ETag"}
     string ETag;
 };
 
-# Represents the optional headers specific to UploadPart function.
+# Represents the optional headers specific to `UploadPart` function.
 #
 # + contentLength - The size of the object, in bytes
 # + contentMD5 - The base64-encoded 128-bit MD5 digest of the message (without the headers)

--- a/ballerina/records.bal
+++ b/ballerina/records.bal
@@ -155,8 +155,7 @@ public type MultipartUploadHeaders record {
 # Represents the details of a part uploaded through the `UploadPart` function.
 #
 # + partNumber - The part number of the file part
-# + ETag - The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, 
-#          not its metadata
+# + ETag - Represents the hash value of the object, which reflects modifications made exclusively to the contents of the object
 public type CompletedPart record {
     @display {label: "Part Number"}
     int partNumber;

--- a/ballerina/records.bal
+++ b/ballerina/records.bal
@@ -127,3 +127,27 @@ public type ObjectCreationHeaders record {
     @display {label: "Content Type"}
     string contentType?;
 };
+
+# Represents the optional headers specific to CreateMultipartUpload function. 
+#
+# + cacheControl - Can be used to specify caching behavior along the request/reply chain
+# + contentDisposition - Specifies presentational information for the object
+# + contentEncoding - Specifies what content encodings have been applied to the object and thus what decoding mechanisms
+#                     must be applied to obtain the media-type referenced by the Content-Type header field
+# + contentLanguage - The language the content is in
+# + contentType - The MIME type of the content
+# + expires - The date and time at which the object is no longer cacheable
+public type MultipartUploadHeaders record {
+    @display {label: "Cache Control"}
+    string cacheControl?;
+    @display {label: "Content Disposition"}
+    string contentDisposition?;
+    @display {label: "Content Encoding"}
+    string contentEncoding?;
+    @display {label: "Content Language"}
+    string contentLanguage?;
+    @display {label: "Content Type"}
+    string contentType?;
+    @display {label: "Expires"}
+    string expires?;
+};

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -212,7 +212,7 @@ function testCreateMultipartUpload() returns error? {
 function testUploadPart() returns error? {
     log:printInfo("amazonS3Client->uploadPart()");
     Client amazonS3Client = check new (amazonS3Config);
-    CompletedPart response = check amazonS3Client->UploadPart(fileName2, testBucketName, content, uploadId, 1);
+    CompletedPart response = check amazonS3Client->uploadPart(fileName2, testBucketName, content, uploadId, 1);
     parts.push(response);
     test:assertTrue(response.ETag.length() > 0, msg = "Failed to upload part");
 }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -27,7 +27,9 @@ configurable string accessKeyId = os:getEnv("ACCESS_KEY_ID");
 configurable string secretAccessKey = os:getEnv("SECRET_ACCESS_KEY");
 configurable string region = os:getEnv("REGION");
 string fileName = "test.txt";
+string fileName2 = "test2.txt";
 string content = "Sample content";
+string uploadId_= "";
 
 ConnectionConfig amazonS3Config = {
     accessKeyId: accessKeyId,
@@ -193,6 +195,21 @@ function testDeleteObject() {
     }
 }
 
+@test:Config {
+    dependsOn: [testListObjects]
+}
+function testCreateMultipartUpload() returns error? {
+    log:printInfo("amazonS3Client->createMultipartUpload()");
+    Client amazonS3Client = check new (amazonS3Config);
+    string|error uploadId = amazonS3Client->createMultipartUpload(fileName, testBucketName);
+    if uploadId is error {
+        test:assertFail(uploadId.toString());
+    } else {
+        uploadId_ = uploadId;
+        test:assertTrue(uploadId.length() > 0, msg = "Failed to create multipart upload");
+    }
+}
+      
 @test:AfterSuite {}
 function testDeleteBucket() {
     log:printInfo("amazonS3Client->deleteBucket()");

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -29,7 +29,7 @@ configurable string region = os:getEnv("REGION");
 string fileName = "test.txt";
 string fileName2 = "test2.txt";
 string content = "Sample content";
-string uploadId= "";
+string uploadId = "";
 CompletedPart[] parts = [];
 
 ConnectionConfig amazonS3Config = {
@@ -211,7 +211,7 @@ function testCreateMultipartUpload() returns error? {
 }
 function testUploadPart() returns error? {
     log:printInfo("amazonS3Client->uploadPart()");
-    Client amazonS3Client =check new (amazonS3Config);
+    Client amazonS3Client = check new (amazonS3Config);
     CompletedPart response = check amazonS3Client->UploadPart(fileName2, testBucketName, content, uploadId, 1);
     parts.push(response);
     test:assertTrue(response.ETag.length() > 0, msg = "Failed to upload part");
@@ -231,13 +231,13 @@ function testCompleteMultipartUpload() returns error? {
 }
 function testDeleteMultipartUpload() returns error? {
     log:printInfo("amazonS3Client->deleteObject() for multipart upload");
-    Client amazonS3Client = check new(amazonS3Config);
-    _ = check amazonS3Client -> deleteObject(testBucketName, fileName2);
+    Client amazonS3Client = check new (amazonS3Config);
+    _ = check amazonS3Client->deleteObject(testBucketName, fileName2);
 }
 
 @test:Config {
     dependsOn: [testListBuckets],
-    before: testCreateMultipartUpload  
+    before: testCreateMultipartUpload
 }
 function testAbortFileUpload() returns error? {
     log:printInfo("amazonS3Client->abortMultipartUpload()");

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -201,7 +201,7 @@ function testDeleteObject() {
 function testCreateMultipartUpload() returns error? {
     log:printInfo("amazonS3Client->createMultipartUpload()");
     Client amazonS3Client = check new (amazonS3Config);
-    string|error uploadId = amazonS3Client->createMultipartUpload(fileName, testBucketName);
+    string|error uploadId = amazonS3Client->createMultipartUpload(fileName2, testBucketName);
     if uploadId is error {
         test:assertFail(uploadId.toString());
     } else {

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -353,6 +353,32 @@ isolated function populateOptionalParameters(map<string> queryParamsMap, string?
     return queryParamsStr;
 }
 
+isolated function populateMultipartUploadHeaders(
+        map<string> requestHeaders,
+        MultipartUploadHeaders? multipartUploadHeaders) {
+    
+    if multipartUploadHeaders != () {
+        if multipartUploadHeaders?.cacheControl != () {
+            requestHeaders[IF_MODIFIED_SINCE] = <string>multipartUploadHeaders?.cacheControl;
+        }
+        if multipartUploadHeaders?.contentDisposition != () {
+            requestHeaders[IF_UNMODIFIED_SINCE] = <string>multipartUploadHeaders?.contentDisposition;
+        }
+        if multipartUploadHeaders?.contentEncoding != () {
+            requestHeaders[IF_MATCH] = <string>multipartUploadHeaders?.contentEncoding;
+        }
+        if multipartUploadHeaders?.contentLanguage != () {
+            requestHeaders[IF_NONE_MATCH] = <string>multipartUploadHeaders?.contentLanguage;
+        }
+        if multipartUploadHeaders?.contentType != () {
+            requestHeaders[RANGE] = <string>multipartUploadHeaders?.contentType;
+        }
+        if multipartUploadHeaders?.expires != () {
+            requestHeaders[RANGE] = <string>multipartUploadHeaders?.expires;
+        }
+    }
+}
+
 isolated function handleHttpResponse(http:Response httpResponse) returns @tainted error? {
     int statusCode = httpResponse.statusCode;
     if (statusCode != http:STATUS_OK && statusCode != http:STATUS_NO_CONTENT) {

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -359,27 +359,27 @@ isolated function populateMultipartUploadHeaders(
     if multipartUploadHeaders is () {
         return;
     }
-    var cacheControl = multipartUploadHeaders?.cacheControl;
+    string? cacheControl = multipartUploadHeaders?.cacheControl;
     if cacheControl is string {
         requestHeaders[IF_MODIFIED_SINCE] = cacheControl;
     }
-    var contentDisposition = multipartUploadHeaders?.contentDisposition;
+    string? contentDisposition = multipartUploadHeaders?.contentDisposition;
     if contentDisposition is string {
         requestHeaders[IF_UNMODIFIED_SINCE] = contentDisposition;
     }
-    var contentEncoding = multipartUploadHeaders?.contentEncoding;
+    string? contentEncoding = multipartUploadHeaders?.contentEncoding;
     if contentEncoding is string {
         requestHeaders[IF_MATCH] = contentEncoding;
     }
-    var contentLanguage = multipartUploadHeaders?.contentLanguage;
+    string? contentLanguage = multipartUploadHeaders?.contentLanguage;
     if contentLanguage is string {
         requestHeaders[IF_NONE_MATCH] = contentLanguage;
     }
-    var contentType = multipartUploadHeaders?.contentType;
+    string? contentType = multipartUploadHeaders?.contentType;
     if contentType is string {
         requestHeaders[RANGE] = contentType;
     }
-    var expires = multipartUploadHeaders?.expires;
+    string? expires = multipartUploadHeaders?.expires;
     if expires is string {
         requestHeaders[RANGE] = expires;
     }
@@ -390,11 +390,13 @@ isolated function populateUploadPartHeaders(map<string> requestHeaders, UploadPa
     if uploadPartHeaders is () {
         return;
     }
-    if uploadPartHeaders?.contentMD5 is string {
-        requestHeaders[CONTENT_MD5] = <string>uploadPartHeaders?.contentMD5;
+    string? contentMD5 = uploadPartHeaders?.contentMD5;
+    if contentMD5 is string {
+        requestHeaders[CONTENT_MD5] = contentMD5;
     }
-    if uploadPartHeaders?.contentLength is string {
-        requestHeaders[CONTENT_LENGTH] = <string>uploadPartHeaders?.contentLength;
+    string? contentLength = uploadPartHeaders?.contentLength;
+    if contentLength is string {
+        requestHeaders[CONTENT_LENGTH] = contentLength;
     }
 }
 

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -356,37 +356,39 @@ isolated function populateOptionalParameters(map<string> queryParamsMap, string?
 isolated function populateMultipartUploadHeaders(
         map<string> requestHeaders,
         MultipartUploadHeaders? multipartUploadHeaders) {
-    
-    if multipartUploadHeaders != () {
-        if multipartUploadHeaders?.cacheControl != () {
-            requestHeaders[IF_MODIFIED_SINCE] = <string>multipartUploadHeaders?.cacheControl;
-        }
-        if multipartUploadHeaders?.contentDisposition != () {
-            requestHeaders[IF_UNMODIFIED_SINCE] = <string>multipartUploadHeaders?.contentDisposition;
-        }
-        if multipartUploadHeaders?.contentEncoding != () {
-            requestHeaders[IF_MATCH] = <string>multipartUploadHeaders?.contentEncoding;
-        }
-        if multipartUploadHeaders?.contentLanguage != () {
-            requestHeaders[IF_NONE_MATCH] = <string>multipartUploadHeaders?.contentLanguage;
-        }
-        if multipartUploadHeaders?.contentType != () {
-            requestHeaders[RANGE] = <string>multipartUploadHeaders?.contentType;
-        }
-        if multipartUploadHeaders?.expires != () {
-            requestHeaders[RANGE] = <string>multipartUploadHeaders?.expires;
-        }
+    if multipartUploadHeaders is () {
+        return;
+    }
+    if multipartUploadHeaders?.cacheControl is string {
+        requestHeaders[IF_MODIFIED_SINCE] = <string>multipartUploadHeaders?.cacheControl;
+    }
+    if multipartUploadHeaders?.contentDisposition is string {
+        requestHeaders[IF_UNMODIFIED_SINCE] = <string>multipartUploadHeaders?.contentDisposition;
+    }
+    if multipartUploadHeaders?.contentEncoding is string {
+        requestHeaders[IF_MATCH] = <string>multipartUploadHeaders?.contentEncoding;
+    }
+    if multipartUploadHeaders?.contentLanguage is string {
+        requestHeaders[IF_NONE_MATCH] = <string>multipartUploadHeaders?.contentLanguage;
+    }
+    if multipartUploadHeaders?.contentType is string {
+        requestHeaders[RANGE] = <string>multipartUploadHeaders?.contentType;
+    }
+    if multipartUploadHeaders?.expires is string {
+        requestHeaders[RANGE] = <string>multipartUploadHeaders?.expires;
     }
 }
 
 isolated function populateUploadPartHeaders(map<string> requestHeaders, UploadPartHeaders? uploadPartHeaders) {
-    if uploadPartHeaders != () {
-        if uploadPartHeaders?.contentMD5 != () {
-            requestHeaders[CONTENT_MD5] = <string>uploadPartHeaders?.contentMD5;
-        }
-        if uploadPartHeaders?.contentLength != () {
-            requestHeaders[CONTENT_LENGTH] = <string>uploadPartHeaders?.contentLength;
-        }     
+
+    if uploadPartHeaders is () {
+        return;
+    }
+    if uploadPartHeaders?.contentMD5 is string {
+        requestHeaders[CONTENT_MD5] = <string>uploadPartHeaders?.contentMD5;
+    }
+    if uploadPartHeaders?.contentLength is string {
+        requestHeaders[CONTENT_LENGTH] = <string>uploadPartHeaders?.contentLength;
     }
 }
 

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -359,23 +359,29 @@ isolated function populateMultipartUploadHeaders(
     if multipartUploadHeaders is () {
         return;
     }
-    if multipartUploadHeaders?.cacheControl is string {
-        requestHeaders[IF_MODIFIED_SINCE] = <string>multipartUploadHeaders?.cacheControl;
+    var cacheControl = multipartUploadHeaders?.cacheControl;
+    if cacheControl is string {
+        requestHeaders[IF_MODIFIED_SINCE] = cacheControl;
     }
-    if multipartUploadHeaders?.contentDisposition is string {
-        requestHeaders[IF_UNMODIFIED_SINCE] = <string>multipartUploadHeaders?.contentDisposition;
+    var contentDisposition = multipartUploadHeaders?.contentDisposition;
+    if contentDisposition is string {
+        requestHeaders[IF_UNMODIFIED_SINCE] = contentDisposition;
     }
-    if multipartUploadHeaders?.contentEncoding is string {
-        requestHeaders[IF_MATCH] = <string>multipartUploadHeaders?.contentEncoding;
+    var contentEncoding = multipartUploadHeaders?.contentEncoding;
+    if contentEncoding is string {
+        requestHeaders[IF_MATCH] = contentEncoding;
     }
-    if multipartUploadHeaders?.contentLanguage is string {
-        requestHeaders[IF_NONE_MATCH] = <string>multipartUploadHeaders?.contentLanguage;
+    var contentLanguage = multipartUploadHeaders?.contentLanguage;
+    if contentLanguage is string {
+        requestHeaders[IF_NONE_MATCH] = contentLanguage;
     }
-    if multipartUploadHeaders?.contentType is string {
-        requestHeaders[RANGE] = <string>multipartUploadHeaders?.contentType;
+    var contentType = multipartUploadHeaders?.contentType;
+    if contentType is string {
+        requestHeaders[RANGE] = contentType;
     }
-    if multipartUploadHeaders?.expires is string {
-        requestHeaders[RANGE] = <string>multipartUploadHeaders?.expires;
+    var expires = multipartUploadHeaders?.expires;
+    if expires is string {
+        requestHeaders[RANGE] = expires;
     }
 }
 


### PR DESCRIPTION
# Description

Adds the following functions to allow users to do multipart uploads to an Amazon S3 Bucket

1. `CreateMultipartUpload()`
2. `UploadPart()`
3. `CompleteMultipartUpload()`
4. `AbortMultipartUpload()`

Reference : https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html

Fixes [issue](https://github.com/ballerina-platform/ballerina-library/issues/6290)

One line release note: 
- Adds multipart upload functions

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version: 2201.8.5
* Operating System: Ubuntu 22.04.4
* Java SDK: 17.0.10

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
