### PR TITLE
Disable GraalVM Schedule

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -1,8 +1,9 @@
 name: GraalVM Check
 
 on:
-  schedule:
-    - cron: "30 18 * * *"
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Purpose

We don't need GraalVM tests running frequently. 

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
