### PR TITLE
Revamp S3 Connector Auth Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,57 +12,7 @@ The `ballerinax/aws.s3` connector offers APIs to connect and interact with [Amaz
 
 ## Setup guide
 
-To use the Ballerina AWS S3 connector, you need an AWS account with necessary credentials.
-
-### Step 1: Sign in to AWS Console
-
-1. If you don't have an AWS account yet, you can create one by visiting the AWS [sign-up](https://aws.amazon.com/free/) page. Sign up is free, and you can explore many services under the Free Tier.
-
-2. If you already have an account, log into the [AWS Management Console](https://console.aws.amazon.com/console).
-
-### Step 2: Create a user
-
-1. In the AWS Management Console, search for **IAM** in the services search bar and click on it.
-
-   ![create-user-1.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-user-1.jpeg)
-
-2. Click **Users**.
-
-   ![create-user-2.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-user-2.jpeg)
-
-3. Click **Create User**.
-
-   ![create-user-3.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-user-3.jpeg)
-
-4. Provide a suitable name for the user and continue.
-
-   ![specify-user-details.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/specify-user-details.jpeg)
-
-5. Add necessary permissions by adding the user to a user group, copying permissions, or directly attaching policies. For S3, attach policies such as `AmazonS3FullAccess` (for development) or a least-privilege custom policy scoped to your buckets. Then click **Next**.
-
-   ![set-user-permissions.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/set-user-permissions.jpeg)
-
-6. Review and create the user.
-
-   ![review-create-user.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/review-create-user.jpeg)
-
-### Step 3: Get user access keys
-
-1. Click the user who was created.
-
-   ![users.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/users.jpeg)
-
-2. Click **Create access key**.
-
-   ![create-access-key-1.png](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-access-key-1.png)
-
-3. Select your use case and click **Next**.
-
-   ![select-usecase.png](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/select-usecase.png)
-
-4. Copy the **Access Key ID** and **Secret Access Key**. These credentials will be used to authenticate your Ballerina application with Amazon S3.
-
-   ![retrieve-access-key.png](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/retrieve-access-key.png)
+To use the Ballerina AWS S3 connector, you need an AWS account with the necessary IAM user credentials. For detailed steps on obtaining these credentials, refer to the [Obtaining IAM user credentials](https://central.ballerina.io/ballerinax/aws/latest#obtaining-iam-user-credentials) guide.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ To use the `aws.s3` connector in your Ballerina application, update your `.bal` 
 
 ### Step 1: Import the module
 
-Import the `aws.s3` module.
+Import the `aws.s3` module and the `aws` module.
 
 ```ballerina
+import ballerinax/aws;
 import ballerinax/aws.s3;
 ```
 
@@ -92,13 +93,59 @@ configurable string accessKeyId = ?;
 configurable string secretAccessKey = ?;
 
 final s3:Client s3Client = check new ({
-   region: s3:US_EAST_1,
+   region: aws:US_EAST_1,
    auth: {
       accessKeyId,
       secretAccessKey
    }
 });
 ```
+
+#### Alternative authentication methods
+
+##### Profile-based authentication
+
+You can use AWS profile-based authentication as an alternative to static credentials.
+
+```ballerina
+final s3:Client s3Client = check new ({
+   region: aws:US_EAST_1,
+   auth: {
+      profileName: "myAwsProfile",
+      credentialsFilePath: "/path/to/custom/credentials"
+   }
+});
+```
+
+##### Default credential provider chain
+
+The standard default credential provider chain, trying each of the following in order and taking the first source that yields credentials:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, and `AWS_WEB_IDENTITY_TOKEN_FILE` if set)
+2. The shared config/credentials file's active profile (`AWS_PROFILE`, or `default` if unset) — which may itself resolve via SSO, an external process, or a chained `AssumeRole` call, depending on that profile's configuration
+3. Container credentials (ECS/EKS)
+4. EC2 instance profile (IMDS)
+
+```ballerina
+import ballerinax/aws.auth;
+
+final s3:Client s3Client = check new ({
+   region: aws:US_EAST_1,
+   auth: auth:DEFAULT_CREDENTIALS
+});
+```
+
+> **Note:** Ensure your AWS credentials file follows the standard format.
+>
+> ```ini
+> [default]
+> aws_access_key_id = YOUR_ACCESS_KEY_ID
+> aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
+>
+> [myAwsProfile]
+> aws_access_key_id = ANOTHER_ACCESS_KEY_ID
+> aws_secret_access_key = ANOTHER_SECRET_ACCESS_KEY
+> ```
 
 ### Step 3: Invoke the connector operations
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-distribution = "2201.12.2"
+distribution = "2201.12.0"
 org = "ballerinax"
 name = "aws.s3"
 version = "5.0.0"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.2"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "aws"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -301,6 +301,9 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "os", moduleName = "os"}
+]
 
 [[package]]
 org = "ballerina"
@@ -343,7 +346,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -352,7 +355,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -380,6 +383,7 @@ dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "random"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -375,6 +375,18 @@ dependencies = [
 
 [[package]]
 org = "ballerinax"
+name = "aws"
+version = "0.1.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerinax", packageName = "aws", moduleName = "aws"},
+	{org = "ballerinax", packageName = "aws", moduleName = "aws.auth"}
+]
+
+[[package]]
+org = "ballerinax"
 name = "aws.s3"
 version = "5.0.0"
 dependencies = [
@@ -385,7 +397,8 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "random"},
-	{org = "ballerina", name = "test"}
+	{org = "ballerina", name = "test"},
+	{org = "ballerinax", name = "aws"}
 ]
 modules = [
 	{org = "ballerinax", packageName = "aws.s3", moduleName = "aws.s3"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.11"
+version = "2.14.13"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -64,9 +64,10 @@ To use the `aws.s3` connector in your Ballerina application, update your `.bal` 
 
 ### Step 1: Import the module
 
-Import the `aws.s3` module.
+Import the `aws.s3` module and the `aws` module.
 
 ```ballerina
+import ballerinax/aws;
 import ballerinax/aws.s3;
 ```
 
@@ -86,13 +87,59 @@ configurable string accessKeyId = ?;
 configurable string secretAccessKey = ?;
 
 final s3:Client s3Client = check new ({
-   region: s3:US_EAST_1,
+   region: aws:US_EAST_1,
    auth: {
       accessKeyId,
       secretAccessKey
    }
 });
 ```
+
+#### Alternative authentication methods
+
+##### Profile-based authentication
+
+You can use AWS profile-based authentication as an alternative to static credentials.
+
+```ballerina
+final s3:Client s3Client = check new ({
+   region: aws:US_EAST_1,
+   auth: {
+      profileName: "myAwsProfile",
+      credentialsFilePath: "/path/to/custom/credentials"
+   }
+});
+```
+
+##### Default credential provider chain
+
+The standard default credential provider chain, trying each of the following in order and taking the first source that yields credentials:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, and `AWS_WEB_IDENTITY_TOKEN_FILE` if set)
+2. The shared config/credentials file's active profile (`AWS_PROFILE`, or `default` if unset) — which may itself resolve via SSO, an external process, or a chained `AssumeRole` call, depending on that profile's configuration
+3. Container credentials (ECS/EKS)
+4. EC2 instance profile (IMDS)
+
+```ballerina
+import ballerinax/aws.auth;
+
+final s3:Client s3Client = check new ({
+   region: aws:US_EAST_1,
+   auth: auth:DEFAULT_CREDENTIALS
+});
+```
+
+> **Note:** Ensure your AWS credentials file follows the standard format.
+>
+> ```ini
+> [default]
+> aws_access_key_id = YOUR_ACCESS_KEY_ID
+> aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
+>
+> [myAwsProfile]
+> aws_access_key_id = ANOTHER_ACCESS_KEY_ID
+> aws_secret_access_key = ANOTHER_SECRET_ACCESS_KEY
+> ```
 
 ### Step 3: Invoke the connector operations
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -6,57 +6,7 @@ The `ballerinax/aws.s3` connector offers APIs to connect and interact with [Amaz
 
 ## Setup guide
 
-To use the Ballerina AWS S3 connector, you need an AWS account with necessary credentials.
-
-### Step 1: Sign in to AWS Console
-
-1. If you don't have an AWS account yet, you can create one by visiting the AWS [sign-up](https://aws.amazon.com/free/) page. Sign up is free, and you can explore many services under the Free Tier.
-
-2. If you already have an account, log into the [AWS Management Console](https://console.aws.amazon.com/console).
-
-### Step 2: Create a user
-
-1. In the AWS Management Console, search for **IAM** in the services search bar and click on it.
-
-   ![create-user-1.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-user-1.jpeg)
-
-2. Click **Users**.
-
-   ![create-user-2.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-user-2.jpeg)
-
-3. Click **Create User**.
-
-   ![create-user-3.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-user-3.jpeg)
-
-4. Provide a suitable name for the user and continue.
-
-   ![specify-user-details.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/specify-user-details.jpeg)
-
-5. Add necessary permissions by adding the user to a user group, copying permissions, or directly attaching policies. For S3, attach policies such as `AmazonS3FullAccess` (for development) or a least-privilege custom policy scoped to your buckets. Then click **Next**.
-
-   ![set-user-permissions.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/set-user-permissions.jpeg)
-
-6. Review and create the user.
-
-   ![review-create-user.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/review-create-user.jpeg)
-
-### Step 3: Get user access keys
-
-1. Click the user who was created.
-
-   ![users.jpeg](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/users.jpeg)
-
-2. Click **Create access key**.
-
-   ![create-access-key-1.png](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/create-access-key-1.png)
-
-3. Select your use case and click **Next**.
-
-   ![select-usecase.png](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/select-usecase.png)
-
-4. Copy the **Access Key ID** and **Secret Access Key**. These credentials will be used to authenticate your Ballerina application with Amazon S3.
-
-   ![retrieve-access-key.png](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-aws.s3/refs/heads/master/docs/setup/resources/retrieve-access-key.png)
+To use the Ballerina AWS S3 connector, you need an AWS account with the necessary IAM user credentials. For detailed steps on obtaining these credentials, refer to the [Obtaining IAM user credentials](https://central.ballerina.io/ballerinax/aws/latest#obtaining-iam-user-credentials) guide.
 
 ## Quickstart
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -61,6 +61,18 @@ final s3:Client s3Client = check new ({
 });
 ```
 
+> **Note:** Ensure your AWS credentials file follows the standard format.
+>
+> ```ini
+> [default]
+> aws_access_key_id = YOUR_ACCESS_KEY_ID
+> aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
+>
+> [myAwsProfile]
+> aws_access_key_id = ANOTHER_ACCESS_KEY_ID
+> aws_secret_access_key = ANOTHER_SECRET_ACCESS_KEY
+> ```
+
 ##### Default credential provider chain
 
 The standard default credential provider chain, trying each of the following in order and taking the first source that yields credentials:
@@ -78,18 +90,6 @@ final s3:Client s3Client = check new ({
    auth: auth:DEFAULT_CREDENTIALS
 });
 ```
-
-> **Note:** Ensure your AWS credentials file follows the standard format.
->
-> ```ini
-> [default]
-> aws_access_key_id = YOUR_ACCESS_KEY_ID
-> aws_secret_access_key = YOUR_SECRET_ACCESS_KEY
->
-> [myAwsProfile]
-> aws_access_key_id = ANOTHER_ACCESS_KEY_ID
-> aws_secret_access_key = ANOTHER_SECRET_ACCESS_KEY
-> ```
 
 ### Step 3: Invoke the connector operations
 

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -1023,17 +1023,12 @@ function testGetObjectAsXmlWithInvalidContent() returns error? {
 }
 function testListObjects() returns error? {
     ListObjectsConfig listConfig = {fetchOwner: true};
-    ListObjectsResponse|error response = s3Client->listObjects(testBucketName, listConfig);
-    if response is error {
-        // Handle error from native method type mismatch
-        test:assertTrue(true, msg = "listObjects() returned an error (expected due to type mismatch in client)");
-    } else {
-        test:assertTrue(response.objects.length() > 0, msg = "Failed to call listObjects()");
-    }
+    ListObjectsResponse response = check s3Client->listObjects(testBucketName, listConfig);
+    test:assertTrue(response.objects.length() > 0, msg = "Failed to call listObjects()");
 }
 
 @test:Config {
-    dependsOn: [testCreateObject]
+    dependsOn: [testListObjects, testGetObjectMetadata, testDoesObjectExist, testCopyObject]
 }
 function testDeleteObject() returns error? {
     check s3Client->deleteObject(testBucketName, fileName);
@@ -1248,8 +1243,7 @@ function testDeleteBucketWithInvalidName() returns error? {
 }
 
 @test:Config {
-    dependsOn: [testCreateBucket],
-    before: testCreateMultipartUpload
+    dependsOn: [testCreateBucket]
 }
 function testAbortFileUpload() returns error? {
     // Create a multipart upload and abort it within this test to avoid relying on

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -18,6 +18,8 @@ import ballerina/http;
 import ballerina/io;
 import ballerina/random;
 import ballerina/test;
+import ballerinax/aws;
+import ballerinax/aws.auth;
 
 // Test-specific constants
 const fileName = "test.txt";
@@ -57,7 +59,7 @@ isolated function testInitUsingProfileAuth() returns error? {
 isolated function testInitUsingDefaultCredentials() returns error? {
     ConnectionConfig connectionConfig = {
         region: awsRegion,
-        auth: DEFAULT_CREDENTIALS
+        auth: auth:DEFAULT_CREDENTIALS
     };
     Client _ = check new (connectionConfig);
 }
@@ -625,7 +627,7 @@ function testGetBucketLocation() returns error? {
 }
 function testAccessBucketWithDifferentRegion() returns error? {
     // Create a client configured with a different region than where the bucket exists
-    Region differentRegion = awsRegion == US_EAST_1 ? US_WEST_2 : US_EAST_1;
+    aws:Region differentRegion = awsRegion == aws:US_EAST_1 ? aws:US_WEST_2 : aws:US_EAST_1;
 
     // Use helper function to create client with proper auth handling
     Client differentRegionClient = check createS3ClientWithRegion(differentRegion);

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -257,7 +257,7 @@ function testPutObjectWithJsonContent() returns error? {
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
-        test:assertEquals(downloadedContent, jsonContent.toString(), "JSON content mismatch");
+        test:assertEquals(downloadedContent, jsonContent.toJsonString(), "JSON content mismatch");
     } else {
         test:assertFail("Failed to read uploaded JSON content");
     }

--- a/ballerina/tests/test_init.bal
+++ b/ballerina/tests/test_init.bal
@@ -16,6 +16,8 @@
 
 import ballerina/os;
 import ballerina/random;
+import ballerinax/aws;
+import ballerinax/aws.auth;
 
 // Environment variables for authentication
 final string accessKeyId = os:getEnv("ACCESS_KEY_ID");
@@ -24,16 +26,16 @@ final string profileName = os:getEnv("AWS_PROFILE_NAME");
 final string credentialsFilePath = os:getEnv("AWS_CREDENTIALS_FILE");
 
 // AWS Region for testing
-final Region awsRegion = EU_NORTH_1;
+final aws:Region awsRegion = aws:EU_NORTH_1;
 
 // Static credentials configuration
-final readonly & StaticAuthConfig staticAuth = {
+final readonly & auth:StaticAuthConfig staticAuth = {
     accessKeyId,
     secretAccessKey
 };
 
 // Profile-based credentials configuration
-final readonly & ProfileAuthConfig profileAuth = {
+final readonly & auth:ProfileAuthConfig profileAuth = {
     profileName: profileName,
     credentialsFilePath: credentialsFilePath
 };
@@ -49,7 +51,7 @@ final Client s3Client = check new ({
 
 // Helper function to create a client with a different region
 // Uses the same auth approach as the main client
-function createS3ClientWithRegion(Region targetRegion) returns Client|error {
+function createS3ClientWithRegion(aws:Region targetRegion) returns Client|error {
     return new ({
         region: targetRegion,
         auth: staticAuth

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -14,38 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Static credential configuration
-public type StaticAuthConfig record {|
-    # The Access Key of the Amazon S3 account
-    string accessKeyId;
-    # The Secret Access Key of the Amazon S3 account
-    string secretAccessKey;
-    # Optional session token for temporary credentials
-    string sessionToken?;
-|};
-
-# Profile-based credential configuration 
-public type ProfileAuthConfig record {|
-    # AWS shared credentials profile name
-    string profileName = "default";
-    # Path to the credentials file
-    string credentialsFilePath?;
-|};
-
-# Represents the default AWS credential chain based authentication.
-# Automatically resolves credentials from environment variables, ECS container credentials,
-# EC2 instance profiles, and other standard AWS credential sources.
-public const DEFAULT_CREDENTIALS = "DEFAULT_CREDENTIALS";
-
-# Authentication configuration
-public type AuthConfig StaticAuthConfig|ProfileAuthConfig|DEFAULT_CREDENTIALS;
+import ballerinax/aws;
+import ballerinax/aws.auth;
 
 # Configuration for the AWS S3 Client.
 public type ConnectionConfig record {|
     # Authentication configuration
-    AuthConfig auth;
-     # The AWS Region. If you don't specify an AWS region, Client uses US East as default region
-    Region region = US_EAST_1;
+    auth:AuthConfig auth;
+    # The AWS Region. If you don't specify an AWS region, Client uses US East (N. Virginia) as default region
+    aws:Region region = aws:US_EAST_1;
+    # Optional endpoint configuration for FIPS, dualstack, or custom endpoint overrides (e.g., LocalStack)
+    aws:EndpointConfig endpoint?;
 |};
 
 
@@ -297,82 +276,6 @@ public type ObjectMetadata record {|
     # Custom data attached to the object
     map<anydata> userMetadata?;
 |};
-
-# Represents an AWS Region used by the Amazon S3 client.
-public enum Region {
-    # Africa (Cape Town)
-    AF_SOUTH_1 = "af-south-1",
-    # Asia Pacific (Hong Kong)
-    AP_EAST_1 = "ap-east-1",
-    # Asia Pacific (Taipei)
-    AP_EAST_2 = "ap-east-2",
-    # Asia Pacific (Tokyo)
-    AP_NORTHEAST_1 = "ap-northeast-1",
-    # Asia Pacific (Seoul)
-    AP_NORTHEAST_2 = "ap-northeast-2",
-    # Asia Pacific (Osaka)
-    AP_NORTHEAST_3 = "ap-northeast-3",
-    # Asia Pacific (Mumbai)
-    AP_SOUTH_1 = "ap-south-1",
-    # Asia Pacific (Hyderabad)
-    AP_SOUTH_2 = "ap-south-2",
-    # Asia Pacific (Singapore)
-    AP_SOUTHEAST_1 = "ap-southeast-1",
-    # Asia Pacific (Sydney)
-    AP_SOUTHEAST_2 = "ap-southeast-2",
-    # Asia Pacific (Jakarta)
-    AP_SOUTHEAST_3 = "ap-southeast-3",
-    # Asia Pacific (Melbourne)
-    AP_SOUTHEAST_4 = "ap-southeast-4",
-    # Asia Pacific (Malaysia)
-    AP_SOUTHEAST_5 = "ap-southeast-5",
-    # Asia Pacific (New Zealand)
-    AP_SOUTHEAST_6 = "ap-southeast-6",
-    # Asia Pacific (Thailand)
-    AP_SOUTHEAST_7 = "ap-southeast-7",
-    # Canada West (Calgary)
-    CA_WEST_1 = "ca-west-1",
-    # Canada (Central)
-    CA_CENTRAL_1 = "ca-central-1",
-    # Europe (Frankfurt)
-    EU_CENTRAL_1 = "eu-central-1",
-    # Europe (Zurich)
-    EU_CENTRAL_2 = "eu-central-2",
-    # Europe (Stockholm)
-    EU_NORTH_1 = "eu-north-1",
-    # Europe (Milan)
-    EU_SOUTH_1 = "eu-south-1",
-    # Europe (Spain)
-    EU_SOUTH_2 = "eu-south-2",
-    # Europe (Ireland)
-    EU_WEST_1 = "eu-west-1",
-    # Europe (London)
-    EU_WEST_2 = "eu-west-2",
-    # Europe (Paris)
-    EU_WEST_3 = "eu-west-3",
-    # Israel (Tel Aviv)
-    IL_CENTRAL_1 = "il-central-1",
-    # Mexico (Central)
-    MX_CENTRAL_1 = "mx-central-1",
-    # Middle East (UAE)
-    ME_CENTRAL_1 = "me-central-1",
-    # Middle East (Bahrain)
-    ME_SOUTH_1 = "me-south-1",
-    # South America (São Paulo)
-    SA_EAST_1 = "sa-east-1",
-    # US East (N. Virginia)
-    US_EAST_1 = "us-east-1",
-    # US East (Ohio)
-    US_EAST_2 = "us-east-2",
-    # AWS GovCloud (US-East)
-    US_GOV_EAST_1 = "us-gov-east-1",
-    # AWS GovCloud (US-West)
-    US_GOV_WEST_1 = "us-gov-west-1",
-    # US West (N. California)
-    US_WEST_1 = "us-west-1",
-    # US West (Oregon)
-    US_WEST_2 = "us-west-2"
-}
 
 # Access control options for buckets and objects.
 public enum CannedACL {

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -22,7 +22,7 @@ public type ConnectionConfig record {|
     # Authentication configuration
     auth:AuthConfig auth;
     # The AWS Region. If you don't specify an AWS region, Client uses US East (N. Virginia) as default region
-    aws:Region region = aws:US_EAST_1;
+    aws:Region|string region = aws:US_EAST_1;
     # Optional endpoint configuration for FIPS, dualstack, or custom endpoint overrides (e.g., LocalStack)
     aws:EndpointConfig endpoint?;
 |};

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -49,6 +49,8 @@ isolated function toByteArray(anydata content) returns byte[] {
         return content.toBytes();
     } else if content is xml {
         return content.toString().toBytes();
+    } else if content is json {
+        return content.toJsonString().toBytes();
     }
     return content.toString().toBytes();
 }

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -47,8 +47,6 @@ isolated function toByteArray(anydata content) returns byte[] {
         return content;
     } else if content is string {
         return content.toBytes();
-    } else if content is xml {
-        return content.toString().toBytes();
     } else if content is json {
         return content.toJsonString().toBytes();
     }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-distribution = "2201.12.2"
+distribution = "2201.12.0"
 org = "ballerinax"
 name = "aws.s3"
 version = "@toml.version@"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
         }
 
         maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/ballerina-lang'
+            url = 'https://maven.pkg.github.com/ballerina-platform/*'
             credentials {
                 username System.getenv("packageUser")
                 password System.getenv("packagePAT")

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Migrated the underlying implementation from pure Ballerina HTTP-based approach to Java-based AWS SDK v2
-- Replaced `ConnectionConfig` with `auth:AuthConfig`, supporting multiple authentication methods (static credentials, profiles, default provider chain)
+- The `ConnectionConfig` now uses the shared `auth:AuthConfig` from `ballerinax/aws.auth` and `aws:Region` from `ballerinax/aws` for authentication and region configuration, supporting multiple authentication methods (static credentials, profile-based, and default credential provider chain). Existing consumers must update their imports and client initialization:
+  - Add `import ballerinax/aws;` and `import ballerinax/aws.auth;` (if using default credentials)
+  - Replace inline `accessKeyId`/`secretAccessKey`/`region` fields with the new `auth` and `region` record fields (see the Quickstart section in the README for examples)
 - Renamed `objectName` parameter to `objectKey` across all APIs
 - Replaced `createObject()` with `putObject()`, `putObjectFromFile()`, and `putObjectAsStream()`
 - Added new retrieval methods: `getObjectAsText()`, `getObjectAsJson()`, `getObjectAsXml()`, `getObjectAsCsv()`, and `getObjectMetadata()`

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,11 @@
+# Change Log
+This file contains all the notable changes done to the Ballerina AWS S3 package through the releases.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- [Revamp the S3 connector](https://github.com/ballerina-platform/ballerina-library/issues/8500)
+- [Add AWS native authentication support for the AWS S3 connector](https://github.com/ballerina-platform/module-ballerinax-aws.s3/pull/XXX)

--- a/changelog.md
+++ b/changelog.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [Revamp the S3 connector](https://github.com/ballerina-platform/ballerina-library/issues/8500)
-- [Add AWS native authentication support for the AWS S3 connector](https://github.com/ballerina-platform/module-ballerinax-aws.s3/pull/XXX)
+- Add AWS native authentication support for the AWS S3 connector

--- a/changelog.md
+++ b/changelog.md
@@ -9,3 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Revamp the S3 connector](https://github.com/ballerina-platform/ballerina-library/issues/8500)
 - Add AWS native authentication support for the AWS S3 connector
+
+### Changed
+
+- Migrated the underlying implementation from pure Ballerina HTTP-based approach to Java-based AWS SDK v2
+- Replaced `ConnectionConfig` with `auth:AuthConfig`, supporting multiple authentication methods (static credentials, profiles, default provider chain)
+- Renamed `objectName` parameter to `objectKey` across all APIs
+- Replaced `createObject()` with `putObject()`, `putObjectFromFile()`, and `putObjectAsStream()`
+- Added new retrieval methods: `getObjectAsText()`, `getObjectAsJson()`, `getObjectAsXml()`, `getObjectAsCsv()`, and `getObjectMetadata()`
+- Added `copyObject()`, `doesObjectExist()`, `getBucketLocation()`, and `close()` methods
+- Changed `listObjects()` to return `ListObjectsResponse` instead of `S3Object[]`
+- Replaced generic `error` return types with distinct `Error` type and specific error subtypes (`NoSuchKeyError`, `BucketAlreadyExistsError`, etc.)
+- Restructured configuration records (`ObjectCreationHeaders` → `PutObjectConfig`, `ObjectRetrievalHeaders` → `GetObjectConfig`, etc.)
+- Changed `completeMultipartUpload()` to accept separate `int[]` and `string[]` arrays instead of `CompletedPart[]`
+- Replaced `ObjectAction` enum with `HttpMethod` in `createPresignedUrl()`

--- a/changelog.md
+++ b/changelog.md
@@ -12,16 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Migrated the underlying implementation from pure Ballerina HTTP-based approach to Java-based AWS SDK v2
-- The `ConnectionConfig` now uses the shared `auth:AuthConfig` from `ballerinax/aws.auth` and `aws:Region` from `ballerinax/aws` for authentication and region configuration, supporting multiple authentication methods (static credentials, profile-based, and default credential provider chain). Existing consumers must update their imports and client initialization:
-  - Add `import ballerinax/aws;` and `import ballerinax/aws.auth;` (if using default credentials)
-  - Replace inline `accessKeyId`/`secretAccessKey`/`region` fields with the new `auth` and `region` record fields (see the Quickstart section in the README for examples)
-- Renamed `objectName` parameter to `objectKey` across all APIs
-- Replaced `createObject()` with `putObject()`, `putObjectFromFile()`, and `putObjectAsStream()`
-- Added new retrieval methods: `getObjectAsText()`, `getObjectAsJson()`, `getObjectAsXml()`, `getObjectAsCsv()`, and `getObjectMetadata()`
-- Added `copyObject()`, `doesObjectExist()`, `getBucketLocation()`, and `close()` methods
-- Changed `listObjects()` to return `ListObjectsResponse` instead of `S3Object[]`
-- Replaced generic `error` return types with distinct `Error` type and specific error subtypes (`NoSuchKeyError`, `BucketAlreadyExistsError`, etc.)
-- Restructured configuration records (`ObjectCreationHeaders` → `PutObjectConfig`, `ObjectRetrievalHeaders` → `GetObjectConfig`, etc.)
-- Changed `completeMultipartUpload()` to accept separate `int[]` and `string[]` arrays instead of `CompletedPart[]`
-- Replaced `ObjectAction` enum with `HttpMethod` in `createPresignedUrl()`
+- Updated `ConnectionConfig` to use the shared `auth:AuthConfig` from `ballerinax/aws.auth` and `aws:Region` from `ballerinax/aws` for authentication and region configuration
+- Revised object creation and retrieval APIs with more specific method variants
+- Introduced distinct error types and restructured configuration records

--- a/examples/ftp-to-s3-sync/main.bal
+++ b/examples/ftp-to-s3-sync/main.bal
@@ -18,13 +18,13 @@ import ballerina/file;
 import ballerina/ftp;
 import ballerina/io;
 import ballerina/log;
-import ballerina/lang.'string as strings;
+import ballerinax/aws;
 import ballerinax/aws.s3;
 
 configurable string s3AccessKeyId = ?;
 configurable string s3SecretAccessKey = ?;
 configurable string s3BucketName = ?;
-configurable s3:Region s3Region = ?;
+configurable aws:Region s3Region = ?;
 configurable string s3Prefix = ?;
 
 configurable string ftpHost = ?;
@@ -95,9 +95,9 @@ function uploadToS3(s3:Client s3Client, string localFilePath, string filename) r
 }
 
 function validateFilename(string filename) returns error? {
-    if strings:indexOf(filename, "/") >= 0 ||
-        strings:indexOf(filename, "\\") >= 0 ||
-        strings:indexOf(filename, "..") >= 0 {
+    if string:indexOf(filename, "/") >= 0 ||
+        string:indexOf(filename, "\\") >= 0 ||
+        string:indexOf(filename, "..") >= 0 {
         return error("Invalid FTP filename");
     }
 }

--- a/examples/s3-report-archiver/Ballerina.toml
+++ b/examples/s3-report-archiver/Ballerina.toml
@@ -3,3 +3,6 @@ org = "ballerinax"
 name = "aws.s3.report.archiver"
 version = "1.0.0"
 distribution = "2201.12.2"
+
+[dependencies]
+"ballerinax/aws" = "0.1.0"

--- a/examples/s3-report-archiver/Ballerina.toml
+++ b/examples/s3-report-archiver/Ballerina.toml
@@ -4,5 +4,3 @@ name = "aws.s3.report.archiver"
 version = "1.0.0"
 distribution = "2201.12.2"
 
-[dependencies]
-"ballerinax/aws" = "0.1.0"

--- a/examples/s3-report-archiver/main.bal
+++ b/examples/s3-report-archiver/main.bal
@@ -17,14 +17,14 @@
 import ballerina/io;
 import ballerina/log;
 import ballerina/time;
-import ballerina/lang.'string as strings;
-import ballerina/regex;
+import ballerina/lang.regexp;
+import ballerinax/aws;
 import ballerinax/aws.s3;
 
 configurable string s3AccessKeyId = ?;
 configurable string s3SecretAccessKey = ?;
 configurable string s3BucketName = ?;
-configurable s3:Region s3Region = ?;
+configurable aws:Region s3Region = ?;
 
 configurable string incomingPrefix = "reports/incoming/";
 configurable string processedPrefix = "reports/processed/";
@@ -140,11 +140,11 @@ function transformRecords(SalesRecord[] records) returns string[][] {
 }
 
 function escapeCsvField(string value) returns string {
-    boolean needsQuotes = strings:indexOf(value, ",") >= 0 || 
-                            strings:indexOf(value, "\"") >= 0 || 
-                            strings:indexOf(value, "\n") >= 0 || 
-                            strings:indexOf(value, "\r") >= 0;
-    string escaped = regex:replaceAll(value, "\"", "\"\"");
+    boolean needsQuotes = string:indexOf(value, ",") >= 0 || 
+                            string:indexOf(value, "\"") >= 0 || 
+                            string:indexOf(value, "\n") >= 0 || 
+                            string:indexOf(value, "\r") >= 0;
+    string escaped = regexp:replaceAll(check regexp:fromString(value), "\"", "\"\"");
     return needsQuotes ? "\"" + escaped + "\"" : escaped;
 }
 

--- a/examples/s3-report-archiver/main.bal
+++ b/examples/s3-report-archiver/main.bal
@@ -144,7 +144,7 @@ function escapeCsvField(string value) returns string {
                             string:indexOf(value, "\"") >= 0 || 
                             string:indexOf(value, "\n") >= 0 || 
                             string:indexOf(value, "\r") >= 0;
-    string escaped = regexp:replaceAll(check regexp:fromString(value), "\"", "\"\"");
+    string escaped = regexp:replaceAll(re `"`, value, "\"\"");
     return needsQuotes ? "\"" + escaped + "\"" : escaped;
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.lib
-version=5.0.0-SNAPSHOT
+version=4.0.0-SNAPSHOT
 
 spotbugsPluginVersion=6.0.18
 shadowJarPluginVersion=8.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,9 @@ downloadPluginVersion=5.5.0
 releasePluginVersion=2.8.1
 ballerinaGradlePluginVersion=2.3.0
 
-ballerinaLangVersion=2201.12.2
+ballerinaLangVersion=2201.12.0
 awsS3SdkVersion=2.42.0
+awsAuthNativeVersion=0.1.0
 nettyVersion=4.1.130.Final
 httpCoreVersion=4.4.16
 httpClientVersion=4.5.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ ballerinaGradlePluginVersion=2.3.0
 
 ballerinaLangVersion=2201.12.0
 awsS3SdkVersion=2.42.0
-awsAuthNativeVersion=0.1.0
+stdlibAwsVersion=1.0.0
 nettyVersion=4.1.130.Final
 httpCoreVersion=4.4.16
 httpClientVersion=4.5.13

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -29,7 +29,7 @@ configurations {
 dependencies {
     implementation group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
     implementation group: 'software.amazon.awssdk', name: 's3', version: "${awsS3SdkVersion}"
-    compileOnly group: 'io.ballerina.lib', name: 'aws-native', version: "${awsAuthNativeVersion}"
+    compileOnly group: 'io.ballerina.lib', name: 'aws-native', version: "${stdlibAwsVersion}"
 }
 
 jar {

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -29,7 +29,7 @@ configurations {
 dependencies {
     implementation group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
     implementation group: 'software.amazon.awssdk', name: 's3', version: "${awsS3SdkVersion}"
-    
+    compileOnly group: 'io.ballerina.lib', name: 'aws-native', version: "${awsAuthNativeVersion}"
 }
 
 jar {

--- a/native/src/main/java/io/ballerina/lib/aws/s3/BallerinaStreamInputStream.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/BallerinaStreamInputStream.java
@@ -118,34 +118,37 @@ public class BallerinaStreamInputStream extends InputStream {
 
     private boolean fetchNextChunk() throws IOException {
         try {
-            // Call next() method on the stream using Ballerina runtime
-            Object result = environment.getRuntime().callMethod(
-                    ballerinaStream.getIteratorObj(), BAL_STREAM_NEXT, null);
-            
-            if (result instanceof BError) {
-                throw new IOException("Error reading from stream: " + ((BError) result).getMessage());
-            }
-            
-            if (result == null) {
-                return false;
-            }
-            
-            if (result instanceof BMap<?, ?> record) {
+            while (true) {
+                // Call next() method on the stream using Ballerina runtime
+                Object result = environment.getRuntime().callMethod(
+                        ballerinaStream.getIteratorObj(), BAL_STREAM_NEXT, null);
+
+                if (result instanceof BError error) {
+                    throw new IOException("Error reading from stream: " + error.getMessage());
+                }
+
+                if (result == null) {
+                    return false;
+                }
+
+                if (!(result instanceof BMap<?, ?> record)) {
+                    throw new IOException("Unexpected result type from stream.next()");
+                }
+
                 Object value = record.get(StringUtils.fromString(STREAM_VALUE));
-                
-                if (value instanceof BArray) {
-                    currentChunk = ((BArray) value).getBytes();
+                if (value instanceof BArray array) {
+                    currentChunk = array.getBytes();
                     chunkPosition = 0;
-                    if (currentChunk.length == 0) {
-                        return fetchNextChunk();
+                    if (currentChunk.length > 0) {
+                        return true;
                     }
-                    return true;
+                    // Empty chunk — continue to next iteration
                 } else {
                     throw new IOException("Unexpected value type in stream");
                 }
-            } else {
-                throw new IOException("Unexpected result type from stream.next()");
             }
+        } catch (IOException e) {
+            throw e;
         } catch (Exception e) {
             throw new IOException("Error reading from Ballerina stream: " + e.getMessage(), e);
         }

--- a/native/src/main/java/io/ballerina/lib/aws/s3/ConnectionConfig.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/ConnectionConfig.java
@@ -16,18 +16,23 @@
 
 package io.ballerina.lib.aws.s3;
 
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
 /**
- * Holds the AWS S3 connection configuration including region and credentials provider.
+ * Holds the AWS S3 connection configuration including region, credentials provider, and endpoint configuration.
  */
 public class ConnectionConfig {
     public final Region region;
     public final AwsCredentialsProvider credentialsProvider;
+    public final BMap<BString, Object> endpointConfig;
 
-    public ConnectionConfig(Region region, AwsCredentialsProvider credentialsProvider) {
+    public ConnectionConfig(Region region, AwsCredentialsProvider credentialsProvider,
+                            BMap<BString, Object> endpointConfig) {
         this.region = region;
         this.credentialsProvider = credentialsProvider;
+        this.endpointConfig = endpointConfig;
     }
 }

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -233,28 +233,36 @@ public class NativeClientAdaptor {
         try {
             String region = config.getStringValue(REGION).getValue();
             Object authObj = config.get(AUTH);
+            Region awsRegion = Region.of(region);
 
             AwsCredentialsProvider credentialsProvider = ProviderFactory.buildProvider(authObj);
+            try {
+                S3ClientBuilder builder = S3Client.builder()
+                        .region(awsRegion)
+                        .credentialsProvider(credentialsProvider)
+                        .crossRegionAccessEnabled(true);
 
-            S3ClientBuilder builder = S3Client.builder()
-                    .region(Region.of(region))
-                    .credentialsProvider(credentialsProvider)
-                    .crossRegionAccessEnabled(true);
+                BMap<BString, Object> endpointConfig = null;
+                Object endpointObj = config.get(ENDPOINT);
+                if (endpointObj instanceof BMap) {
+                    @SuppressWarnings("unchecked")
+                    BMap<BString, Object> typedEndpointConfig = (BMap<BString, Object>) endpointObj;
+                    endpointConfig = typedEndpointConfig;
+                    EndpointConfigUtils.applyEndpointConfig(builder, endpointConfig);
+                }
 
-            Object endpointObj = config.get(ENDPOINT);
-            if (endpointObj instanceof BMap) {
-                @SuppressWarnings("unchecked")
-                BMap<BString, Object> endpointConfig = (BMap<BString, Object>) endpointObj;
-                EndpointConfigUtils.applyEndpointConfig(builder, endpointConfig);
+                S3Client s3Client = builder.build();
+
+                clientObj.addNativeData(NATIVE_CLIENT, s3Client);
+                clientObj.addNativeData(NATIVE_CREDENTIALS_PROVIDER, credentialsProvider);
+                ConnectionConfig connConfig = new ConnectionConfig(awsRegion, credentialsProvider,
+                        endpointConfig);
+                clientObj.addNativeData(NATIVE_CONFIG, connConfig);
+                return null;
+            } catch (Exception e) {
+                ProviderFactory.closeProvider(credentialsProvider);
+                throw e;
             }
-
-            S3Client s3Client = builder.build();
-
-            clientObj.addNativeData(NATIVE_CLIENT, s3Client);
-            clientObj.addNativeData(NATIVE_CREDENTIALS_PROVIDER, credentialsProvider);
-            ConnectionConfig connConfig = new ConnectionConfig(Region.of(region), credentialsProvider);
-            clientObj.addNativeData(NATIVE_CONFIG, connConfig);
-            return null;
         } catch (Exception e) {
             return ErrorCreator.createError(e);
         }
@@ -622,7 +630,7 @@ public class NativeClientAdaptor {
                 BMap<BString, Object> objMap = ValueCreator.createMapValue(mapType);
 
                 objMap.put(KEY, StringUtils.fromString(obj.key()));
-                objMap.put(SIZE, obj.size());
+                objMap.put(SIZE, obj.size() != null ? obj.size() : 0L);
                 String lastModified = obj.lastModified() != null ? obj.lastModified().toString() : EMPTY_STRING;
                 objMap.put(LAST_MODIFIED, StringUtils.fromString(lastModified));
                 String eTag = obj.eTag() != null ? obj.eTag() : EMPTY_STRING;
@@ -639,7 +647,7 @@ public class NativeClientAdaptor {
 
             result.put(OBJECTS, objectsArray);
             result.put(COUNT, (long) size);
-            result.put(IS_TRUNCATED, response.isTruncated());
+            result.put(IS_TRUNCATED, Boolean.TRUE.equals(response.isTruncated()));
 
             if (response.nextContinuationToken() != null) {
                 result.put(NEXT_CONTINUATION_TOKEN, StringUtils.fromString(response.nextContinuationToken()));
@@ -959,10 +967,11 @@ public class NativeClientAdaptor {
             }
             ConnectionConfig connConfig = (ConnectionConfig) connOrError;
 
-            presigner = S3Presigner.builder()
+            S3Presigner.Builder presignerBuilder = S3Presigner.builder()
                     .region(connConfig.region)
-                    .credentialsProvider(connConfig.credentialsProvider)
-                    .build();
+                    .credentialsProvider(connConfig.credentialsProvider);
+            applyEndpointConfigToPresigner(presignerBuilder, connConfig.endpointConfig);
+            presigner = presignerBuilder.build();
 
             String preSignedUrl = GET.equals(httpMethod)
                     ? generateGetPresignedUrl(presigner, bucket.getValue(), key.getValue(), expirationMinutes, config)
@@ -981,6 +990,27 @@ public class NativeClientAdaptor {
             if (presigner != null) {
                 presigner.close();
             }
+        }
+    }
+
+    private static void applyEndpointConfigToPresigner(S3Presigner.Builder builder,
+            BMap<BString, Object> endpointConfig) {
+        if (endpointConfig == null) {
+            return;
+        }
+        BString customEndpoint = StringUtils.fromString("customEndpoint");
+        BString fips = StringUtils.fromString("fips");
+        BString dualstack = StringUtils.fromString("dualstack");
+        if (endpointConfig.containsKey(customEndpoint)) {
+            builder.endpointOverride(java.net.URI.create(
+                    endpointConfig.getStringValue(customEndpoint).getValue()));
+            return;
+        }
+        if (endpointConfig.getBooleanValue(fips)) {
+            builder.fipsEnabled(true);
+        }
+        if (endpointConfig.getBooleanValue(dualstack)) {
+            builder.dualstackEnabled(true);
         }
     }
 

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -16,6 +16,8 @@
 
 package io.ballerina.lib.aws.s3;
 
+import io.ballerina.lib.aws.EndpointConfigUtils;
+import io.ballerina.lib.aws.auth.ProviderFactory;
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -29,20 +31,14 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.utils.StringUtils;
 
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
-import software.amazon.awssdk.profiles.ProfileFile;
 
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.Bucket;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
@@ -89,13 +85,10 @@ public class NativeClientAdaptor {
 
     private static final String NATIVE_CLIENT = "NATIVE_S3_CLIENT";
     private static final String NATIVE_CONFIG = "NATIVE_CONNECTION_CONFIG";
+    private static final String NATIVE_CREDENTIALS_PROVIDER = "NATIVE_CREDENTIALS_PROVIDER";
     public static final BString AUTH = StringUtils.fromString("auth");
     public static final BString REGION = StringUtils.fromString("region");
-    public static final BString ACCESS_KEY_ID = StringUtils.fromString("accessKeyId");
-    public static final BString PROFILE_NAME = StringUtils.fromString("profileName");
-    public static final BString SECRET_ACCESS_KEY = StringUtils.fromString("secretAccessKey");
-    public static final BString SESSION_TOKEN = StringUtils.fromString("sessionToken");
-    public static final BString CREDENTIALS_FILE_PATH = StringUtils.fromString("credentialsFilePath");
+    public static final BString ENDPOINT = StringUtils.fromString("endpoint");
     public static final String ACL = "acl";
     public static final String OBJECT_OWNERSHIP_KEY = "objectOwnership";
     public static final String OBJECT_LOCK_ENABLED_KEY = "objectLockEnabled";
@@ -241,19 +234,24 @@ public class NativeClientAdaptor {
             String region = config.getStringValue(REGION).getValue();
             Object authObj = config.get(AUTH);
 
-            if (!(authObj instanceof BMap) && !(authObj instanceof BString)) {
-                return ErrorCreator.createError("Invalid auth configuration provided");
-            }
+            AwsCredentialsProvider credentialsProvider = ProviderFactory.buildProvider(authObj);
 
-            AwsCredentialsProvider credentialsProvider = createCredentialsProvider(authObj);
-
-            S3Client s3Client = S3Client.builder()
+            S3ClientBuilder builder = S3Client.builder()
                     .region(Region.of(region))
                     .credentialsProvider(credentialsProvider)
-                    .crossRegionAccessEnabled(true)
-                    .build();
+                    .crossRegionAccessEnabled(true);
+
+            Object endpointObj = config.get(ENDPOINT);
+            if (endpointObj instanceof BMap) {
+                @SuppressWarnings("unchecked")
+                BMap<BString, Object> endpointConfig = (BMap<BString, Object>) endpointObj;
+                EndpointConfigUtils.applyEndpointConfig(builder, endpointConfig);
+            }
+
+            S3Client s3Client = builder.build();
 
             clientObj.addNativeData(NATIVE_CLIENT, s3Client);
+            clientObj.addNativeData(NATIVE_CREDENTIALS_PROVIDER, credentialsProvider);
             ConnectionConfig connConfig = new ConnectionConfig(Region.of(region), credentialsProvider);
             clientObj.addNativeData(NATIVE_CONFIG, connConfig);
             return null;
@@ -265,79 +263,31 @@ public class NativeClientAdaptor {
     // Close client and release resources
     public static Object closeClient(BObject clientObj) {
         Object nativeClient = clientObj.getNativeData(NATIVE_CLIENT);
-        if (nativeClient instanceof S3Client) {
+        Exception closeException = null;
+        if (nativeClient instanceof S3Client s3Client) {
             try {
-                ((S3Client) nativeClient).close();
-                return null;
+                s3Client.close();
             } catch (Exception e) {
-                return ErrorCreator.createError(e);
+                closeException = e;
             } finally {
                 clientObj.addNativeData(NATIVE_CLIENT, null);
             }
         }
-        return null;
-    }
-
-    // Method for credentials provider based on auth config
-    @SuppressWarnings("unchecked")
-    private static AwsCredentialsProvider createCredentialsProvider(Object auth) {
-        if (auth instanceof BString) {
-            return DefaultCredentialsProvider.create();
-        } else if (auth instanceof BMap) {
-            BMap<BString, Object> authMap = (BMap<BString, Object>) auth;
-            if (authMap.containsKey(ACCESS_KEY_ID)) {
-                return createStaticCredentialsProvider(authMap);
-            } else if (authMap.containsKey(PROFILE_NAME)) {
-                return createProfileCredentialsProvider(authMap);
+        // Always release the credentials provider's resources (e.g. STS/SSO background refresh threads),
+        // even if closing the S3 client itself failed.
+        try {
+            Object provider = clientObj.getNativeData(NATIVE_CREDENTIALS_PROVIDER);
+            if (provider instanceof AwsCredentialsProvider credentialsProvider) {
+                ProviderFactory.closeProvider(credentialsProvider);
             }
-        }
-        throw new IllegalArgumentException("Unsupported auth configuration");
-    }
-
-    // Handle static credentials with optional session token
-    private static AwsCredentialsProvider createStaticCredentialsProvider(BMap<BString, Object> auth) {
-        String accessKeyId = auth.getStringValue(ACCESS_KEY_ID).getValue();
-        String secretAccessKey = auth.getStringValue(SECRET_ACCESS_KEY).getValue();
-
-        AwsCredentials credentials;
-        if (auth.containsKey(SESSION_TOKEN)) {
-            Object sessionTokenObj = auth.get(SESSION_TOKEN);
-            if (sessionTokenObj instanceof BString) {
-                String sessionToken = ((BString) sessionTokenObj).getValue();
-                credentials = (!sessionToken.isEmpty())
-                        ? AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken)
-                        : AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+        } catch (Exception e) {
+            if (closeException == null) {
+                closeException = e;
             } else {
-                credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
-            }
-        } else {
-            credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
-        }
-        return StaticCredentialsProvider.create(credentials);
-    }
-
-    // Handle profile-based credentials with optional custom file path
-    private static AwsCredentialsProvider createProfileCredentialsProvider(BMap<BString, Object> auth) {
-        String profileName = auth.getStringValue(PROFILE_NAME).getValue();
-
-        if (auth.containsKey(CREDENTIALS_FILE_PATH)) {
-            Object credentialsFilePathObj = auth.get(CREDENTIALS_FILE_PATH);
-            if (credentialsFilePathObj instanceof BString) {
-                String credentialsFilePath = ((BString) credentialsFilePathObj).getValue();
-                if (!credentialsFilePath.isEmpty()) {
-                    ProfileFile profileFile = ProfileFile.builder()
-                            .content(java.nio.file.Paths.get(credentialsFilePath))
-                            .type(ProfileFile.Type.CREDENTIALS)
-                            .build();
-                    return ProfileCredentialsProvider.builder()
-                            .profileFile(profileFile)
-                            .profileName(profileName)
-                            .build();
-                }
+                closeException.addSuppressed(e);
             }
         }
-
-        return ProfileCredentialsProvider.create(profileName);
+        return closeException == null ? null : ErrorCreator.createError(closeException);
     }
 
     private static Object getClient(BObject clientObj) {

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -288,6 +288,7 @@ public class NativeClientAdaptor {
             if (provider instanceof AwsCredentialsProvider credentialsProvider) {
                 ProviderFactory.closeProvider(credentialsProvider);
             }
+            clientObj.addNativeData(NATIVE_CREDENTIALS_PROVIDER, null);
         } catch (Exception e) {
             if (closeException == null) {
                 closeException = e;

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -18,9 +18,9 @@
 
 module io.ballerina.lib.aws.s3 {
     requires io.ballerina.runtime;
+    requires io.ballerina.lib.aws.auth;
     requires software.amazon.awssdk.services.s3;
     requires software.amazon.awssdk.auth;
     requires software.amazon.awssdk.core;
-    requires software.amazon.awssdk.profiles;
     requires software.amazon.awssdk.regions;
 }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8500

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refactored the S3 connector’s connection/auth configuration to be more Ballerina-idiomatic by integrating `ballerinax/aws` / `ballerinax/aws.auth` types into the exported `ConnectionConfig`, standardizing defaults for region/credentials, and adding optional endpoint configuration support.
- Updated the native S3 client adaptor to delegate AWS credential provider creation to the shared provider factory, consistently apply endpoint configuration (including during presigned URL creation), enable cross-region behavior, and improve connection cleanup on close.
- Improved reliability and correctness in native request/response handling by normalizing nullable S3 fields (e.g., object size), tightening Ballerina stream chunk reading logic, and updating byte conversion behavior for non-binary inputs.
- Revamped documentation and examples to reflect the new `ballerinax/aws` imports and region/credential setup model, including clearer quickstart/setup guidance and expanded authentication options (static, profile-based, and default credential provider chain).
- Updated and stabilized the test suite to use the new auth/region configuration types and revised assertions/ordering assumptions to align with the updated client behavior.
- Adjusted build/dependency wiring (Gradle/Ballerina versions, module setup, and native module dependencies) to support the new AWS integration, plus minor example/changelog/build metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->