### PR TITLE
Revamp get and put object methods

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerinax"
 name = "aws.s3"
-version = "5.0.0"
+version = "4.0.0"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Cloud/Object Storage", "Cost/Paid", "Vendor/Amazon", "Area/Storage & File Management", "Type/Connector"]
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib.aws.s3"
 artifactId = "aws.s3-native"
-version = "5.0.0"
-path = "../native/build/libs/aws.s3-native-5.0.0-SNAPSHOT.jar"
+version = "4.0.0"
+path = "../native/build/libs/aws.s3-native-4.0.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "software.amazon.awssdk"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -53,26 +53,12 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "data.csv"
-version = "0.8.2"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "log"}
-]
-modules = [
-	{org = "ballerina", packageName = "data.csv", moduleName = "data.csv"}
-]
-
-[[package]]
-org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
-]
-modules = [
-	{org = "ballerina", packageName = "data.jsondata", moduleName = "data.jsondata"}
 ]
 
 [[package]]
@@ -125,6 +111,7 @@ modules = [
 org = "ballerina"
 name = "io"
 version = "1.8.1"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -210,6 +197,7 @@ dependencies = [
 org = "ballerina"
 name = "lang.object"
 version = "0.0.0"
+scope = "testOnly"
 
 [[package]]
 org = "ballerina"
@@ -243,6 +231,7 @@ dependencies = [
 org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -251,6 +240,7 @@ dependencies = [
 org = "ballerina"
 name = "log"
 version = "2.14.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -288,6 +278,7 @@ dependencies = [
 org = "ballerina"
 name = "observe"
 version = "1.6.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -376,7 +367,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "aws"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -388,10 +379,8 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "aws.s3"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
-	{org = "ballerina", name = "data.csv"},
-	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -295,12 +295,20 @@ public isolated client class Client {
     } external;
 
     # Uploads a part in a multipart upload.
+    # Supported content types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
+    # `stream<byte[], error?>`, and `stream<record {}, error?>`.
+    #
+    # For `record {}` content, the object key must end with `.json` or `.xml`.
+    # `.json` keys serialize the record as JSON; `.xml` keys serialize as XML.
+    # For `record {}[]` and `stream<record {}, error?>` content, the object key must end with `.csv`.
+    # The records are serialized as CSV (field names as headers).
+    # `stream<byte[], error?>` content is collected into bytes before uploading.
     #
     # + bucketName - The name of the bucket
     # + objectKey - The path of the object
     # + uploadId - The upload ID from createMultipartUpload
     # + partNumber - The part number (1-10000)
-    # + content - The part content (string | xml | json | byte[])
+    # + content - The part content
     # + config - Optional upload part configuration
     # + return - ETag of the uploaded part or an Error
     @display {label: "Upload Part"}
@@ -308,10 +316,35 @@ public isolated client class Client {
             @display {label: "Object Key"} string objectKey,
             @display {label: "Upload ID"} string uploadId,
             @display {label: "Part Number"} int partNumber,
-            @display {label: "Content"} ContentType content,
+            @display {label: "Content"} UploadContent content,
             *UploadPartConfig config)
             returns @display {label: "ETag"} string|Error {
-        byte[] converted = toByteArray(content);
+        byte[] converted;
+        string lowerKey = objectKey.toLowerAscii();
+        if content is stream<byte[], error?> {
+            converted = check collectByteStream(content);
+        } else if content is stream<record {}, error?> {
+            if !lowerKey.endsWith(CSV_EXTENSION) {
+                return error Error("stream<record {}, error?> content requires a '.csv' file extension in the object key");
+            }
+            record {}[] records = check collectRecordStream(content);
+            converted = convertRecordsToCsv(records);
+        } else if content is record {}[] {
+            if !lowerKey.endsWith(CSV_EXTENSION) {
+                return error Error("record {}[] content requires a '.csv' file extension in the object key");
+            }
+            converted = convertRecordsToCsv(content);
+        } else if content is record {} {
+            if lowerKey.endsWith(XML_EXTENSION) {
+                converted = convertRecordToXml(content, objectKey).toBytes();
+            } else if lowerKey.endsWith(JSON_EXTENSION) {
+                converted = content.toJsonString().toBytes();
+            } else {
+                return error Error("record {} content requires a '.json' or '.xml' file extension in the object key");
+            }
+        } else {
+            converted = toByteArray(<ContentType>content);
+        }
         return check nativeUploadPart(self, bucketName, objectKey, uploadId, partNumber, converted, config);
     }
 

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -95,8 +95,10 @@ public isolated client class Client {
     # Supported content types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
     # `stream<byte[], error?>`, and `stream<record {}, error?>`.
     #
-    # `record {}` content is serialized as JSON. `record {}[]` and `stream<record {}, error?>`
-    # content is serialized as CSV (field names as headers).
+    # For `record {}` content, the object key must end with `.json` or `.xml`.
+    # `.json` keys serialize the record as JSON; `.xml` keys serialize as XML.
+    # For `record {}[]` and `stream<record {}, error?>` content, the object key must end with `.csv`.
+    # The records are serialized as CSV (field names as headers).
     # `stream<byte[], error?>` content is collected into bytes before uploading.
     #
     # + bucketName - The name of the bucket
@@ -111,18 +113,27 @@ public isolated client class Client {
             *PutObjectConfig config) returns Error? {
 
         byte[] converted;
+        string lowerKey = objectKey.toLowerAscii();
         if content is stream<byte[], error?> {
             converted = check collectByteStream(content);
         } else if content is stream<record {}, error?> {
+            if !lowerKey.endsWith(CSV_EXTENSION) {
+                return error Error("stream<record {}, error?> content requires a '.csv' file extension in the object key");
+            }
             record {}[] records = check collectRecordStream(content);
             converted = convertRecordsToCsv(records);
         } else if content is record {}[] {
+            if !lowerKey.endsWith(CSV_EXTENSION) {
+                return error Error("record {}[] content requires a '.csv' file extension in the object key");
+            }
             converted = convertRecordsToCsv(content);
         } else if content is record {} {
-            if objectKey.toLowerAscii().endsWith(".xml") {
+            if lowerKey.endsWith(XML_EXTENSION) {
                 converted = convertRecordToXml(content, objectKey).toBytes();
-            } else {
+            } else if lowerKey.endsWith(JSON_EXTENSION) {
                 converted = content.toJsonString().toBytes();
+            } else {
+                return error Error("record {} content requires a '.json' or '.xml' file extension in the object key");
             }
         } else {
             converted = toByteArray(<ContentType>content);
@@ -151,9 +162,10 @@ public isolated client class Client {
     # Supported target types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
     # `stream<byte[], error?>`, and `stream<record {}, error?>`.
     #
-    # For `record {}`, the object key's file extension determines parsing:
-    # `.xml` files are parsed as XML, all others as JSON.
-    # For `record {}[]`, the content is parsed as CSV (first row = headers).
+    # For `record {}`, the object key must end with `.json` or `.xml`.
+    # `.json` keys parse the content as JSON; `.xml` keys parse as XML.
+    # For `record {}[]` and `stream<record {}, error?>`, the object key must end with `.csv`.
+    # The content is parsed as CSV (first row = headers).
     # For large objects, use `stream<byte[], error?>` to avoid loading the entire content into memory.
     #
     # + bucketName - The name of the bucket

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -119,7 +119,11 @@ public isolated client class Client {
         } else if content is record {}[] {
             converted = convertRecordsToCsv(content);
         } else if content is record {} {
-            converted = content.toJsonString().toBytes();
+            if objectKey.toLowerAscii().endsWith(".xml") {
+                converted = convertRecordToXml(content, objectKey).toBytes();
+            } else {
+                converted = content.toJsonString().toBytes();
+            }
         } else {
             converted = toByteArray(<ContentType>content);
         }

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -125,127 +125,30 @@ public isolated client class Client {
         'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
     } external;
 
-    # Downloads an S3 object as a stream.
+    # Downloads an S3 object and returns its content in the requested type.
+    # The target type is inferred from the left-hand side of the assignment.
+    # Supported target types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
+    # `stream<byte[], error?>`, and `stream<record {}, error?>`.
+    #
+    # For `record {}`, the object key's file extension determines parsing:
+    # `.xml` files are parsed as XML, all others as JSON.
+    # For `record {}[]`, the content is parsed as CSV (first row = headers).
+    # For large objects, use `stream<byte[], error?>` to avoid loading the entire content into memory.
     #
     # + bucketName - The name of the bucket
     # + objectKey - The path of the object
+    # + targetType - The typedesc of the target type
     # + config - Optional retrieval configuration
-    # + return - A stream of byte chunks containing the object content, or an Error
-    @display {label: "Get Object As Stream"}
-    remote isolated function getObjectAsStream(@display {label: "Bucket Name"} string bucketName,
-            @display {label: "Object Key"} string objectKey,
-            *GetObjectConfig config) 
-            returns @display {label: "Byte Stream"} stream<byte[], error?>|Error {
-        StreamIterator streamImpl = check nativeGetObjectAsStream(self, bucketName, objectKey, config);
-        return new stream<byte[], Error?>(streamImpl);
-    }
-
-    # Downloads an S3 object and returns its content as a byte array.
-    # This method loads the entire object into memory and is suitable for smaller objects.
-    # For large objects, consider using `getObjectAsStream` instead.
-    #
-    # + bucketName - The name of the bucket
-    # + objectKey - The path of the object
-    # + config - Optional retrieval configuration
-    # + return - The object content as `byte[]` or an Error
+    # + return - The object content in the requested type or an Error
     @display {label: "Get Object"}
     remote isolated function getObject(@display {label: "Bucket Name"} string bucketName,
             @display {label: "Object Key"} string objectKey,
-            *GetObjectConfig config) 
-            returns @display {label: "Content"} byte[]|Error {
-        return nativeGetObject(self, bucketName, objectKey, config);
-    }
-
-    # Downloads an S3 object and returns its content as a string.
-    # This method loads the entire object into memory and is suitable for smaller objects.
-    # For large objects, consider using `getObjectAsStream` instead.
-    #
-    # + bucketName - The name of the bucket
-    # + objectKey - The path of the object
-    # + config - Optional retrieval configuration
-    # + return - The object content as `string` or an Error
-    @display {label: "Get Object As Text"}
-    remote isolated function getObjectAsText(@display {label: "Bucket Name"} string bucketName,
-            @display {label: "Object Key"} string objectKey,
-            *GetObjectConfig config) 
-            returns @display {label: "Text"} string|Error {
-        byte[] bytes = check nativeGetObject(self, bucketName, objectKey, config);
-        var textRes = string:fromBytes(bytes);
-        if textRes is string {
-            return textRes;
-        } else {
-            return error Error("Failed to convert bytes to string: " + textRes.message(), textRes);
-        }
-    }
-
-    # Downloads an S3 object and parses it as JSON.
-    # This method loads the entire object into memory and is suitable for smaller objects.
-    # For large objects, consider using `getObjectAsStream` instead.
-    #
-    # + bucketName - The name of the bucket
-    # + objectKey - The path of the object
-    # + config - Optional retrieval configuration
-    # + return - The object content as `json` or an Error
-    @display {label: "Get Object As JSON"}
-    remote isolated function getObjectAsJson(@display {label: "Bucket Name"} string bucketName,
-            @display {label: "Object Key"} string objectKey,
+            typedesc<RetrievableType> targetType = <>,
             *GetObjectConfig config)
-            returns @display {label: "JSON"} json|Error {
-        byte[] bytes = check nativeGetObject(self, bucketName, objectKey, config);
-        json|jsondata:Error result = jsondata:parseBytes(bytes);
-        if result is jsondata:Error {
-            return error Error("Failed to parse JSON: " + result.message(), result);
-        }
-        return result;
-    }
-
-    # Downloads an S3 object and parses it as XML.
-    # This method loads the entire object into memory and is suitable for smaller objects.
-    # For large objects, consider using `getObjectAsStream` instead.
-    #
-    # + bucketName - The name of the bucket
-    # + objectKey - The path of the object
-    # + config - Optional retrieval configuration
-    # + return - The object content as `xml` or an Error
-    @display {label: "Get Object As XML"}
-    remote isolated function getObjectAsXml(@display {label: "Bucket Name"} string bucketName,
-            @display {label: "Object Key"} string objectKey,
-            *GetObjectConfig config) 
-            returns @display {label: "XML"} xml|Error {
-        byte[] bytes = check nativeGetObject(self, bucketName, objectKey, config);
-        var textRes = string:fromBytes(bytes);
-        if textRes is string {
-            var parsed = xml:fromString(textRes);
-            if parsed is xml {
-                return parsed;
-            } else {
-                return error Error("Failed to parse XML: " + parsed.message(), parsed);
-            }
-        } else {
-            return error Error("Failed to convert bytes to string: " + textRes.message(), textRes);
-        }
-    }
-
-    # Downloads an S3 object and parses it as CSV.
-    # This method loads the entire object into memory and is suitable for smaller objects.
-    # For large objects, consider using `getObjectAsStream` instead.
-    #
-    # + bucketName - The name of the bucket
-    # + objectKey - The path of the object
-    # + config - Optional retrieval configuration
-    # + return - The CSV content as `string[][]` or an Error
-    @display {label: "Get Object As CSV"}
-    remote isolated function getObjectAsCsv(@display {label: "Bucket Name"} string bucketName,
-            @display {label: "Object Key"} string objectKey,
-            *GetObjectConfig config)
-            returns @display {label: "CSV"} string[][]|Error {
-        byte[] bytes = check nativeGetObject(self, bucketName, objectKey, config);
-        string[][]|csv:Error result = csv:parseBytes(bytes);
-        if result is csv:Error {
-            return error Error("Failed to parse CSV: " + result.message(), result);
-        }
-        return result;
-    }
+            returns targetType|Error = @java:Method {
+        name: "getObjectWithType",
+        'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
+    } external;
 
     # Deletes an S3 object from an S3 bucket.
     #

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -92,18 +92,21 @@ public isolated client class Client {
     } external;
 
     # Uploads an S3 object from content.
-    # Supported content types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
-    # `stream<byte[], error?>`, and `stream<record {}, error?>`.
-    #
-    # For `record {}` content, the object key must end with `.json` or `.xml`.
-    # `.json` keys serialize the record as JSON; `.xml` keys serialize as XML.
-    # For `record {}[]` and `stream<record {}, error?>` content, the object key must end with `.csv`.
-    # The records are serialized as CSV (field names as headers).
-    # `stream<byte[], error?>` content is collected into bytes before uploading.
     #
     # + bucketName - The name of the bucket
     # + objectKey - The path of the object
-    # + content - The object content
+    # + content - The object content (to be used for automatic data binding).
+    #             Supported types:
+    #             - Built-in subtypes of `anydata` (`byte[]`, `string`, `json`, `xml`)
+    #             - Custom types (e.g., `User`, `Student`, etc.), written as JSON for a `.json` object key
+    #             and as XML for a `.xml` object key
+    #             - Arrays of custom types (e.g., `User[]`, `Student[]`, etc.), written as CSV with the field
+    #             names as headers, needs a `.csv` object key
+    #             - Stream of custom types (e.g., `stream<User, error?>`), written as CSV, needs a `.csv`
+    #             object key
+    #             - Stream of byte arrays (`stream<byte[], error?>`), collected into bytes before uploading
+    #             The `PutObjectConfig.fileFormat` configuration overrides the format inferred from the
+    #             object key
     # + config - Optional upload configuration
     # + return - An Error if the upload fails
     @display {label: "Put Object"}
@@ -160,20 +163,21 @@ public isolated client class Client {
         'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
     } external;
 
-    # Downloads an S3 object and returns its content in the requested type.
-    # The target type is inferred from the left-hand side of the assignment.
-    # Supported target types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
-    # `stream<byte[], error?>`, and `stream<record {}, error?>`.
-    #
-    # For `record {}`, the object key must end with `.json` or `.xml`.
-    # `.json` keys parse the content as JSON; `.xml` keys parse as XML.
-    # For `record {}[]` and `stream<record {}, error?>`, the object key must end with `.csv`.
-    # The content is parsed as CSV (first row = headers).
-    # For large objects, use `stream<byte[], error?>` to avoid loading the entire content into memory.
+    # Downloads an S3 object from an S3 bucket.
     #
     # + bucketName - The name of the bucket
     # + objectKey - The path of the object
-    # + targetType - The typedesc of the target type
+    # + targetType - Expected return type (to be used for automatic data binding).
+    #                Supported types:
+    #                - Built-in subtypes of `anydata` (`byte[]`, `string`, `json`, `xml`)
+    #                - Custom types (e.g., `User`, `Student`, etc.), read as JSON for a `.json` object key
+    #                and as XML for a `.xml` object key
+    #                - Arrays of custom types (e.g., `User[]`, `Student[]`, etc.), read as CSV with the first
+    #                row as headers, needs a `.csv` object key
+    #                - Stream of custom types (e.g., `stream<User, error?>`), read as CSV, needs a `.csv`
+    #                object key
+    #                - Stream of byte arrays (`stream<byte[], error?>`), to retrieve large objects without
+    #                loading the entire content into memory
     # + config - Optional retrieval configuration
     # + return - The object content in the requested type or an Error
     @display {label: "Get Object"}

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -14,8 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/data.csv;
-import ballerina/data.jsondata;
 import ballerina/jballerina.java;
 
 # The AWS S3 Client Connector.
@@ -94,18 +92,37 @@ public isolated client class Client {
     } external;
 
     # Uploads an S3 object from content.
+    # Supported content types: `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`,
+    # `stream<byte[], error?>`, and `stream<record {}, error?>`.
+    #
+    # `record {}` content is serialized as JSON. `record {}[]` and `stream<record {}, error?>`
+    # content is serialized as CSV (field names as headers).
+    # `stream<byte[], error?>` content is collected into bytes before uploading.
     #
     # + bucketName - The name of the bucket
     # + objectKey - The path of the object
-    # + content - The object content (string | xml | json | byte[])
+    # + content - The object content
     # + config - Optional upload configuration
     # + return - An Error if the upload fails
     @display {label: "Put Object"}
     remote isolated function putObject(@display {label: "Bucket Name"} string bucketName,
             @display {label: "Object Key"} string objectKey,
-            @display {label: "Content"} ContentType content,
+            @display {label: "Content"} UploadContent content,
             *PutObjectConfig config) returns Error? {
-        byte[] converted = toByteArray(content);
+
+        byte[] converted;
+        if content is stream<byte[], error?> {
+            converted = check collectByteStream(content);
+        } else if content is stream<record {}, error?> {
+            record {}[] records = check collectRecordStream(content);
+            converted = convertRecordsToCsv(records);
+        } else if content is record {}[] {
+            converted = convertRecordsToCsv(content);
+        } else if content is record {} {
+            converted = content.toJsonString().toBytes();
+        } else {
+            converted = toByteArray(<ContentType>content);
+        }
         check nativePutObjectWithContent(self, bucketName, objectKey, converted, config);
     }
 
@@ -361,16 +378,6 @@ isolated function nativeListBuckets(Client clientObj) returns json|Error = @java
 
 isolated function nativePutObjectWithContent(Client clientObj, string bucket, string key, byte[] content, PutObjectConfig config) returns Error? = @java:Method {
     name: "putObjectWithContent",
-    'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
-} external;
-
-isolated function nativeGetObject(Client clientObj, string bucket, string key, GetObjectConfig config) returns byte[]|Error = @java:Method {
-    name: "getObject",
-    'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
-} external;
-
-isolated function nativeGetObjectAsStream(Client clientObj, string bucket, string key, GetObjectConfig config) returns StreamIterator|Error = @java:Method {
-    name: "getObjectAsStream",
     'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
 } external;
 

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -112,28 +112,31 @@ public isolated client class Client {
             @display {label: "Content"} UploadContent content,
             *PutObjectConfig config) returns Error? {
 
-        byte[] converted;
+        byte[] converted = [];
         string lowerKey = objectKey.toLowerAscii();
+        FileFormat? format = config.fileFormat;
         if content is stream<byte[], error?> {
             converted = check collectByteStream(content);
         } else if content is stream<record {}, error?> {
-            if !lowerKey.endsWith(CSV_EXTENSION) {
-                return error Error("stream<record {}, error?> content requires a '.csv' file extension in the object key");
+            if format != CSV && (format is FileFormat || !lowerKey.endsWith(CSV_EXTENSION)) {
+                return error Error("stream<record {}, error?> content requires CSV format");
             }
             record {}[] records = check collectRecordStream(content);
             converted = convertRecordsToCsv(records);
         } else if content is record {}[] {
-            if !lowerKey.endsWith(CSV_EXTENSION) {
-                return error Error("record {}[] content requires a '.csv' file extension in the object key");
+            if format != CSV && (format is FileFormat || !lowerKey.endsWith(CSV_EXTENSION)) {
+                return error Error("record {}[] content requires CSV format");
             }
             converted = convertRecordsToCsv(content);
         } else if content is record {} {
-            if lowerKey.endsWith(XML_EXTENSION) {
+            if format == XML || (format is () && lowerKey.endsWith(XML_EXTENSION)) {
                 converted = convertRecordToXml(content, objectKey).toBytes();
-            } else if lowerKey.endsWith(JSON_EXTENSION) {
+            } else if format == JSON || (format is () && lowerKey.endsWith(JSON_EXTENSION)) {
                 converted = content.toJsonString().toBytes();
+            } else if format == CSV {
+                return error Error("record {} content cannot be serialized as CSV");
             } else {
-                return error Error("record {} content requires a '.json' or '.xml' file extension in the object key");
+                return error Error("record {} content requires a '.json' or '.xml' file extension in the object key, or an explicit fileFormat");
             }
         } else {
             converted = toByteArray(<ContentType>content);
@@ -319,28 +322,31 @@ public isolated client class Client {
             @display {label: "Content"} UploadContent content,
             *UploadPartConfig config)
             returns @display {label: "ETag"} string|Error {
-        byte[] converted;
+        byte[] converted = [];
         string lowerKey = objectKey.toLowerAscii();
+        FileFormat? format = config.fileFormat;
         if content is stream<byte[], error?> {
             converted = check collectByteStream(content);
         } else if content is stream<record {}, error?> {
-            if !lowerKey.endsWith(CSV_EXTENSION) {
-                return error Error("stream<record {}, error?> content requires a '.csv' file extension in the object key");
+            if format != CSV && (format is FileFormat || !lowerKey.endsWith(CSV_EXTENSION)) {
+                return error Error("stream<record {}, error?> content requires CSV format");
             }
             record {}[] records = check collectRecordStream(content);
             converted = convertRecordsToCsv(records);
         } else if content is record {}[] {
-            if !lowerKey.endsWith(CSV_EXTENSION) {
-                return error Error("record {}[] content requires a '.csv' file extension in the object key");
+            if format != CSV && (format is FileFormat || !lowerKey.endsWith(CSV_EXTENSION)) {
+                return error Error("record {}[] content requires CSV format");
             }
             converted = convertRecordsToCsv(content);
         } else if content is record {} {
-            if lowerKey.endsWith(XML_EXTENSION) {
+            if format == XML || (format is () && lowerKey.endsWith(XML_EXTENSION)) {
                 converted = convertRecordToXml(content, objectKey).toBytes();
-            } else if lowerKey.endsWith(JSON_EXTENSION) {
+            } else if format == JSON || (format is () && lowerKey.endsWith(JSON_EXTENSION)) {
                 converted = content.toJsonString().toBytes();
+            } else if format == CSV {
+                return error Error("record {} content cannot be serialized as CSV");
             } else {
-                return error Error("record {} content requires a '.json' or '.xml' file extension in the object key");
+                return error Error("record {} content requires a '.json' or '.xml' file extension in the object key, or an explicit fileFormat");
             }
         } else {
             converted = toByteArray(<ContentType>content);

--- a/ballerina/stream_iterator.bal
+++ b/ballerina/stream_iterator.bal
@@ -38,6 +38,32 @@ isolated class StreamIterator {
     }
 }
 
+# Iterator that yields records from an in-memory array, used for record streaming.
+isolated class RecordStreamIterator {
+
+    private final readonly & record {}[] records;
+    private int index = 0;
+
+    isolated function init(record {}[] records) {
+        self.records = records.cloneReadOnly();
+    }
+
+    public isolated function next() returns record {|record {} value;|}|Error? {
+        lock {
+            if self.index >= self.records.length() {
+                return;
+            }
+            readonly & record {} rec = self.records[self.index];
+            self.index += 1;
+            return {value: rec.clone()};
+        }
+    }
+
+    public isolated function close() returns Error? {
+        return;
+    }
+}
+
 isolated function nativeReadStreamBytes(StreamIterator streamObj) returns byte[]|Error? = @java:Method {
     name: "readStreamBytes",
     'class: "io.ballerina.lib.aws.s3.StreamIteratorUtils"

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -363,17 +363,11 @@ function testPutObjectWithRecordContentAsXmlWithNestedPath() returns error? {
     dependsOn: [testCreateBucket]
 }
 function testPutObjectWithRecordContentNonXmlExtension() returns error? {
-    // Verify that non-.xml keys still serialize as JSON
+    // Verify that non-.json/.xml keys return an error for record {} content
     string objectKey = "test_record_put.txt";
     PersonRecord person = {name: "Charlie", age: 40, city: "SF"};
-    check s3Client->putObject(testBucketName, objectKey, person);
-
-    // Should be JSON, so we can read as json
-    json response = check s3Client->getObject(testBucketName, objectKey);
-    test:assertEquals(response.name, "Charlie", "Non-XML record name mismatch");
-    test:assertEquals(response.age, 40, "Non-XML record age mismatch");
-
-    check s3Client->deleteObject(testBucketName, objectKey);
+    Error? result = s3Client->putObject(testBucketName, objectKey, person);
+    test:assertTrue(result is Error, "Expected an error for unsupported file extension with record {} content");
 }
 
 @test:Config {
@@ -1164,47 +1158,44 @@ function testGetObjectAsRecordArray() returns error? {
     dependsOn: [testGetObjectAsRecordArray]
 }
 function testGetObjectAsRecordStream() returns error? {
-    // Create a JSON array object
-    json jsonArray = [
-        {"name": "Alice", "age": 30, "city": "NY"},
-        {"name": "Bob", "age": 25, "city": "LA"}
-    ];
-    string jsonKey = "test-record-stream.json";
-    check s3Client->putObject(testBucketName, jsonKey, jsonArray);
+    // Create CSV content (first row = headers, subsequent rows = data)
+    string csvContent = "name,age,city\nAlice,30,NY\nBob,25,LA";
+    string csvKey = "test-record-stream.csv";
+    check s3Client->putObject(testBucketName, csvKey, csvContent);
 
     // Get the object as stream<record{}, error?> using getObject
-    stream<PersonRecord, error?> response = check s3Client->getObject(testBucketName, jsonKey);
+    stream<CsvPersonRecord, error?> response = check s3Client->getObject(testBucketName, csvKey);
 
-    PersonRecord[] records = [];
-    check from PersonRecord rec in response
+    CsvPersonRecord[] records = [];
+    check from CsvPersonRecord rec in response
         do {
             records.push(rec);
         };
 
     test:assertEquals(records.length(), 2, "Expected 2 records from stream");
     test:assertEquals(records[0].name, "Alice", "Stream record[0] name mismatch");
-    test:assertEquals(records[0].age, 30, "Stream record[0] age mismatch");
+    test:assertEquals(records[0].age, "30", "Stream record[0] age mismatch");
     test:assertEquals(records[1].name, "Bob", "Stream record[1] name mismatch");
-    test:assertEquals(records[1].age, 25, "Stream record[1] age mismatch");
+    test:assertEquals(records[1].age, "25", "Stream record[1] age mismatch");
 
     // Cleanup
-    check s3Client->deleteObject(testBucketName, jsonKey);
+    check s3Client->deleteObject(testBucketName, csvKey);
 }
 
 @test:Config {
     dependsOn: [testGetObjectAsRecordStream]
 }
 function testPutRecordArrayGetRecordStream() returns error? {
-    json jsonArray = [
-        {"name": "Alice", "age": 30, "city": "NY"},
-        {"name": "Bob", "age": 25, "city": "LA"}
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
     ];
-    string jsonKey = "test-put-arr-get-stream.json";
-    check s3Client->putObject(testBucketName, jsonKey, jsonArray);
+    string csvKey = "test-put-arr-get-stream.csv";
+    check s3Client->putObject(testBucketName, csvKey, people);
 
-    stream<PersonRecord, error?> response = check s3Client->getObject(testBucketName, jsonKey);
-    PersonRecord[] records = [];
-    check from PersonRecord rec in response
+    stream<CsvPersonRecord, error?> response = check s3Client->getObject(testBucketName, csvKey);
+    CsvPersonRecord[] records = [];
+    check from CsvPersonRecord rec in response
         do {
             records.push(rec);
         };
@@ -1212,20 +1203,21 @@ function testPutRecordArrayGetRecordStream() returns error? {
     test:assertEquals(records[0].name, "Alice", "Round-trip stream record[0] name mismatch");
     test:assertEquals(records[1].name, "Bob", "Round-trip stream record[1] name mismatch");
 
-    check s3Client->deleteObject(testBucketName, jsonKey);
+    check s3Client->deleteObject(testBucketName, csvKey);
 }
 
 @test:Config {
     dependsOn: [testPutRecordArrayGetRecordStream]
 }
 function testGetObjectAsRecordFromNonJsonExtension() returns error? {
-    json jsonContent = {"name": "Charlie", "age": 40, "city": "SF"};
+    // Upload JSON content as a string with a .txt extension
+    string jsonContent = "{\"name\": \"Charlie\", \"age\": 40, \"city\": \"SF\"}";
     string txtKey = "test-record-nojson-ext.txt";
     check s3Client->putObject(testBucketName, txtKey, jsonContent);
 
-    PersonRecord response = check s3Client->getObject(testBucketName, txtKey);
-    test:assertEquals(response.name, "Charlie", "Non-json extension record name mismatch");
-    test:assertEquals(response.age, 40, "Non-json extension record age mismatch");
+    // Expecting an error since record {} target requires .json or .xml extension
+    PersonRecord|Error response = s3Client->getObject(testBucketName, txtKey);
+    test:assertTrue(response is Error, "Expected an error for unsupported file extension with record {} target type");
 
     check s3Client->deleteObject(testBucketName, txtKey);
 }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -392,6 +392,107 @@ function testPutObjectWithRecordArrayContent() returns error? {
 @test:Config {
     dependsOn: [testCreateBucket]
 }
+function testPutObjectRecordAsJsonWithFileFormatOverride() returns error? {
+    // Use a non-.json key but override with fileFormat = JSON
+    string objectKey = "test_record_format_override.dat";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+    check s3Client->putObject(testBucketName, objectKey, person, fileFormat = JSON);
+    byte[] response = check s3Client->getObject(testBucketName, objectKey);
+    json parsed = check (check string:fromBytes(response)).fromJsonString();
+    test:assertEquals(check parsed.name, "Alice", "JSON fileFormat override name mismatch");
+    test:assertEquals(check parsed.age, 30, "JSON fileFormat override age mismatch");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectRecordAsXmlWithFileFormatOverride() returns error? {
+    // Use a non-.xml key but override with fileFormat = XML
+    string objectKey = "test_record_format_override_xml.dat";
+    XmlPersonRecord person = {name: "Bob", age: "25", city: "LA"};
+    check s3Client->putObject(testBucketName, objectKey, person, fileFormat = XML);
+    byte[] response = check s3Client->getObject(testBucketName, objectKey);
+    string responseStr = check string:fromBytes(response);
+    test:assertTrue(responseStr.includes("Bob"), "XML fileFormat override should contain name");
+    test:assertTrue(responseStr.includes("25"), "XML fileFormat override should contain age");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectRecordArrayAsCsvWithFileFormatOverride() returns error? {
+    // Use a non-.csv key but override with fileFormat = CSV
+    string objectKey = "test_records_format_override.dat";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
+    ];
+    check s3Client->putObject(testBucketName, objectKey, people, fileFormat = CSV);
+    byte[] response = check s3Client->getObject(testBucketName, objectKey);
+    string responseStr = check string:fromBytes(response);
+    test:assertTrue(responseStr.includes("Alice"), "CSV fileFormat override should contain Alice");
+    test:assertTrue(responseStr.includes("Bob"), "CSV fileFormat override should contain Bob");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectRecordStreamAsCsvWithFileFormatOverride() returns error? {
+    // Use a non-.csv key but override with fileFormat = CSV
+    string objectKey = "test_record_stream_format_override.dat";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
+    ];
+    stream<CsvPersonRecord, error?> recordStream = people.toStream();
+    check s3Client->putObject(testBucketName, objectKey, recordStream, fileFormat = CSV);
+    byte[] response = check s3Client->getObject(testBucketName, objectKey);
+    string responseStr = check string:fromBytes(response);
+    test:assertTrue(responseStr.includes("Alice"), "CSV stream fileFormat override should contain Alice");
+    test:assertTrue(responseStr.includes("Bob"), "CSV stream fileFormat override should contain Bob");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectRecordWithCsvFileFormatError() returns error? {
+    // record {} cannot be serialized as CSV
+    string objectKey = "test_record_csv_error.csv";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+    Error? result = s3Client->putObject(testBucketName, objectKey, person, fileFormat = CSV);
+    test:assertTrue(result is Error, "Expected an error for record {} with fileFormat = CSV");
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectRecordArrayWithJsonFileFormatError() returns error? {
+    // record {}[] requires CSV format, not JSON
+    string objectKey = "test_records_json_error.csv";
+    CsvPersonRecord[] people = [{name: "Alice", age: "30", city: "NY"}];
+    Error? result = s3Client->putObject(testBucketName, objectKey, people, fileFormat = JSON);
+    test:assertTrue(result is Error, "Expected an error for record {}[] with fileFormat = JSON");
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectRecordStreamWithXmlFileFormatError() returns error? {
+    // stream<record {}, error?> requires CSV format, not XML
+    string objectKey = "test_record_stream_xml_error.csv";
+    CsvPersonRecord[] people = [{name: "Alice", age: "30", city: "NY"}];
+    stream<CsvPersonRecord, error?> recordStream = people.toStream();
+    Error? result = s3Client->putObject(testBucketName, objectKey, recordStream, fileFormat = XML);
+    test:assertTrue(result is Error, "Expected an error for stream<record {}, error?> with fileFormat = XML");
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
 function testPutObjectWithByteStream() returns error? {
     string objectKey = "test_byte_stream_put.txt";
     string textContent = "Hello from byte stream upload";
@@ -1677,6 +1778,53 @@ function testUploadPartWithRecordStreamInvalidExtension() returns error? {
     string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
     string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, recordStream);
     test:assertTrue(result is Error, "Expected an error for stream<record {}, error?> with .json extension in uploadPart");
+
+    check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
+}
+
+// ---- fileFormat override tests for uploadPart ----
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordJsonFileFormatOverride() returns error? {
+    // Use a non-.json key but override with fileFormat = JSON
+    string objectKey = "multipart_record_format.dat";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, person, fileFormat = JSON);
+    test:assertTrue(result is string, "uploadPart with fileFormat = JSON should succeed");
+
+    check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordArrayCsvFileFormatOverride() returns error? {
+    // Use a non-.csv key but override with fileFormat = CSV
+    string objectKey = "multipart_records_format.dat";
+    CsvPersonRecord[] people = [{name: "Alice", age: "30", city: "NY"}];
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, people, fileFormat = CSV);
+    test:assertTrue(result is string, "uploadPart with fileFormat = CSV for record []should succeed");
+
+    check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordCsvFileFormatError() returns error? {
+    // record {} cannot be serialized as CSV
+    string objectKey = "multipart_record_csv_err.csv";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, person, fileFormat = CSV);
+    test:assertTrue(result is Error, "Expected an error for record {} with fileFormat = CSV in uploadPart");
 
     check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
 }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -1526,6 +1526,161 @@ function testAbortFileUpload() returns error? {
     test:assertFalse(exists, msg = "Object should not exist after aborting multipart upload");
 }
 
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordAsJson() returns error? {
+    string objectKey = "multipart_record.json";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string etag = check s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, person);
+    test:assertTrue(etag.length() > 0, msg = "Failed to upload record part as JSON");
+
+    check s3Client->completeMultipartUpload(testBucketName, objectKey, mpUploadId, [1], [etag]);
+
+    PersonRecord response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response, person, "Multipart record JSON content mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordAsXml() returns error? {
+    string objectKey = "multipart_record.xml";
+    XmlPersonRecord person = {name: "Bob", age: "25", city: "LA"};
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string etag = check s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, person);
+    test:assertTrue(etag.length() > 0, msg = "Failed to upload record part as XML");
+
+    check s3Client->completeMultipartUpload(testBucketName, objectKey, mpUploadId, [1], [etag]);
+
+    XmlPersonRecord response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response, person, "Multipart record XML content mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordArray() returns error? {
+    string objectKey = "multipart_records.csv";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
+    ];
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string etag = check s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, people);
+    test:assertTrue(etag.length() > 0, msg = "Failed to upload record array part as CSV");
+
+    check s3Client->completeMultipartUpload(testBucketName, objectKey, mpUploadId, [1], [etag]);
+
+    CsvPersonRecord[] response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response.length(), 2, "Expected 2 records from multipart CSV upload");
+    test:assertEquals(response[0].name, "Alice", "Multipart CSV record[0] name mismatch");
+    test:assertEquals(response[1].name, "Bob", "Multipart CSV record[1] name mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithByteStream() returns error? {
+    string objectKey = "multipart_bytestream.txt";
+    string textContent = "Hello from byte stream upload part";
+    byte[][] chunks = [textContent.toBytes()];
+    stream<byte[], error?> byteStream = chunks.toStream();
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string etag = check s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, byteStream);
+    test:assertTrue(etag.length() > 0, msg = "Failed to upload byte stream part");
+
+    check s3Client->completeMultipartUpload(testBucketName, objectKey, mpUploadId, [1], [etag]);
+
+    string response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response, textContent, "Multipart byte stream content mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordStream() returns error? {
+    string objectKey = "multipart_recordstream.csv";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
+    ];
+    stream<CsvPersonRecord, error?> recordStream = people.toStream();
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string etag = check s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, recordStream);
+    test:assertTrue(etag.length() > 0, msg = "Failed to upload record stream part as CSV");
+
+    check s3Client->completeMultipartUpload(testBucketName, objectKey, mpUploadId, [1], [etag]);
+
+    CsvPersonRecord[] response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response.length(), 2, "Expected 2 records from multipart record stream upload");
+    test:assertEquals(response[0].name, "Alice", "Multipart record stream[0] name mismatch");
+    test:assertEquals(response[1].name, "Bob", "Multipart record stream[1] name mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordInvalidExtension() returns error? {
+    string objectKey = "multipart_record.txt";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, person);
+    test:assertTrue(result is Error, "Expected an error for record {} with .txt extension in uploadPart");
+
+    check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordArrayInvalidExtension() returns error? {
+    string objectKey = "multipart_records.json";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"}
+    ];
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, people);
+    test:assertTrue(result is Error, "Expected an error for record {}[] with .json extension in uploadPart");
+
+    check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testUploadPartWithRecordStreamInvalidExtension() returns error? {
+    string objectKey = "multipart_recordstream.json";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"}
+    ];
+    stream<CsvPersonRecord, error?> recordStream = people.toStream();
+
+    string mpUploadId = check s3Client->createMultipartUpload(testBucketName, objectKey);
+    string|Error result = s3Client->uploadPart(testBucketName, objectKey, mpUploadId, 1, recordStream);
+    test:assertTrue(result is Error, "Expected an error for stream<record {}, error?> with .json extension in uploadPart");
+
+    check s3Client->abortMultipartUpload(testBucketName, objectKey, mpUploadId);
+}
+
 @test:AfterSuite {}
 function testDeleteBucket() returns error? {
     // Clean up any remaining objects before deleting bucket

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -21,6 +21,24 @@ import ballerina/test;
 import ballerinax/aws;
 import ballerinax/aws.auth;
 
+type PersonRecord record {|
+    string name;
+    int age;
+    string city;
+|};
+
+type XmlPersonRecord record {|
+    string name;
+    string age;
+    string city;
+|};
+
+type CsvPersonRecord record {|
+    string name;
+    string age;
+    string city;
+|};
+
 // Test-specific constants
 const fileName = "test.txt";
 const fileName2 = "test2.txt";
@@ -132,7 +150,7 @@ function testPutObjectFromFile() returns error? {
     check s3Client->putObjectFromFile(testBucketName, fileFromPath, tempFilePath);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, fileFromPath);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, fileFromPath);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
@@ -196,7 +214,7 @@ function testPutObjectWithStringContent() returns error? {
     check s3Client->putObject(testBucketName, objectKey, stringContent);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
@@ -221,7 +239,7 @@ function testPutObjectWithXmlContent() returns error? {
     check s3Client->putObject(testBucketName, objectKey, xmlContent);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
@@ -253,7 +271,7 @@ function testPutObjectWithJsonContent() returns error? {
     check s3Client->putObject(testBucketName, objectKey, jsonContent);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
@@ -278,7 +296,7 @@ function testPutObjectWithByteArrayContent() returns error? {
     check s3Client->putObject(testBucketName, objectKey, byteContent);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         test:assertEquals(chunk.value, byteContent, "Byte array content mismatch");
@@ -288,6 +306,69 @@ function testPutObjectWithByteArrayContent() returns error? {
     check response.close();
     
     // Clean up
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectWithRecordContent() returns error? {
+    string objectKey = "test_record_put.json";
+    PersonRecord person = {name: "Alice", age: 30, city: "NY"};
+    check s3Client->putObject(testBucketName, objectKey, person);
+    PersonRecord response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response, person, "Record content mismatch");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectWithRecordArrayContent() returns error? {
+    string objectKey = "test_record_array_put.csv";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
+    ];
+    check s3Client->putObject(testBucketName, objectKey, people);
+    CsvPersonRecord[] response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response.length(), 2, "Expected 2 records");
+    test:assertEquals(response[0].name, "Alice", "Record[0] name mismatch");
+    test:assertEquals(response[0].age, "30", "Record[0] age mismatch");
+    test:assertEquals(response[1].name, "Bob", "Record[1] name mismatch");
+    test:assertEquals(response[1].age, "25", "Record[1] age mismatch");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectWithByteStream() returns error? {
+    string objectKey = "test_byte_stream_put.txt";
+    string textContent = "Hello from byte stream upload";
+    byte[][] chunks = [textContent.toBytes()];
+    stream<byte[], error?> byteStream = chunks.toStream();
+    check s3Client->putObject(testBucketName, objectKey, byteStream);
+    string response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response, textContent, "Byte stream content mismatch");
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectWithRecordStream() returns error? {
+    string objectKey = "test_record_stream_put.csv";
+    CsvPersonRecord[] people = [
+        {name: "Alice", age: "30", city: "NY"},
+        {name: "Bob", age: "25", city: "LA"}
+    ];
+    stream<CsvPersonRecord, error?> recordStream = people.toStream();
+    check s3Client->putObject(testBucketName, objectKey, recordStream);
+    CsvPersonRecord[] response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response.length(), 2, "Expected 2 records from stream upload");
+    test:assertEquals(response[0].name, "Alice", "Stream record[0] name mismatch");
+    test:assertEquals(response[1].name, "Bob", "Stream record[1] name mismatch");
     check s3Client->deleteObject(testBucketName, objectKey);
 }
 
@@ -309,7 +390,7 @@ function testPutObjectAsStream() returns error? {
     check s3Client->putObject(testBucketName, objectKey, fileContent);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
@@ -384,7 +465,7 @@ function testPutObjectAsStreamLargeFile() returns error? {
     check s3Client->putObject(testBucketName, objectKey, fileContent);
     
     // Verify by downloading and checking content length
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     byte[] fullContent = [];
     check from byte[] bytes in response
         do {
@@ -423,7 +504,7 @@ function testPutObjectAsStreamDirect() returns error? {
     check s3Client->putObjectAsStream(testBucketName, objectKey, fileStream, config);
     
     // Verify by downloading and checking content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
 
     byte[] fullContent = [];
     check from byte[] bytes in response
@@ -525,7 +606,7 @@ function testUploadPartAsStreamDirect() returns error? {
     check s3Client->completeMultipartUpload(testBucketName, objectKey, streamUploadId, [1], [etag]);
     
     // Verify the uploaded object
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {byte[] value;}? chunk = check response.next();
 
     if chunk is record {byte[] value;} {
@@ -599,7 +680,7 @@ function testUploadMultiplePartsAsStreamDirect() returns error? {
     check s3Client->completeMultipartUpload(testBucketName, objectKey, multiPartUploadId, [1, 2], [etag1, etag2]);
     
     // Verify the uploaded object size
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     byte[] fullDownloadedContent = [];
     check from byte[] bytes in response
         do {
@@ -720,7 +801,7 @@ function testCopyObject() returns error? {
     check s3Client->copyObject(testBucketName, sourceKey, testBucketName, destinationKey);
     
     // Verify the copied object exists and has same content
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, destinationKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, destinationKey);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string downloadedContent = check string:fromBytes(chunk.value);
@@ -901,7 +982,7 @@ function testCreatePresignedUrlWithInvalidBucketName() returns error? {
     dependsOn: [testCreateObject]
 }
 function testGetObjectAsStream() returns error? {
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, fileName);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, fileName);
     record {|byte[] value;|}? chunk = check response.next();
     if chunk is record {|byte[] value;|} {
         string resContent = check string:fromBytes(chunk.value);
@@ -924,9 +1005,9 @@ function testGetObject() returns error? {
     dependsOn: [testCreateObject]
 }
 function testGetObjectAsString() returns error? {
-    // Test getting object as string using the getObjectAsText API
-    string stringResponse = check s3Client->getObjectAsText(testBucketName, fileName);
-    test:assertEquals(check string:fromBytes(content), stringResponse, "Content mismatch in getObjectAsText");
+    // Test getting object as string using getObject with string type inference
+    string stringResponse = check s3Client->getObject(testBucketName, fileName);
+    test:assertEquals(check string:fromBytes(content), stringResponse, "Content mismatch in getObject as string");
 }
 
 @test:Config {
@@ -938,8 +1019,8 @@ function testGetObjectAsJson() returns error? {
     string jsonKey = "test-json-object.json";
     check s3Client->putObject(testBucketName, jsonKey, jsonContent);
     
-    // Get the object as JSON using the getObjectAsJson API
-    json response = check s3Client->getObjectAsJson(testBucketName, jsonKey);
+    // Get the object as JSON using getObject with json type inference
+    json response = check s3Client->getObject(testBucketName, jsonKey);
     test:assertEquals(response, jsonContent, "JSON content mismatch");
     
     // Cleanup
@@ -955,8 +1036,8 @@ function testGetObjectAsXml() returns error? {
     string xmlKey = "test-xml-object.xml";
     check s3Client->putObject(testBucketName, xmlKey, xmlContent);
     
-    // Get the object as XML using the getObjectAsXml API
-    xml response = check s3Client->getObjectAsXml(testBucketName, xmlKey);
+    // Get the object as XML using getObject with xml type inference
+    xml response = check s3Client->getObject(testBucketName, xmlKey);
     test:assertEquals(response.toString(), xmlContent.toString(), "XML content mismatch");
     
     // Cleanup
@@ -966,28 +1047,162 @@ function testGetObjectAsXml() returns error? {
 @test:Config {
     dependsOn: [testGetObjectAsXml]
 }
-function testGetObjectAsCsv() returns error? {
+function testGetObjectAsRecord() returns error? {
+    // Create a JSON object that maps to a record
+    json jsonContent = {"name": "Alice", "age": 30, "city": "NY"};
+    string jsonKey = "test-record-object.json";
+    check s3Client->putObject(testBucketName, jsonKey, jsonContent);
+
+    // Get the object as a typed record using getObject with record type inference
+    PersonRecord response = check s3Client->getObject(testBucketName, jsonKey);
+    test:assertEquals(response.name, "Alice", "Record name mismatch");
+    test:assertEquals(response.age, 30, "Record age mismatch");
+    test:assertEquals(response.city, "NY", "Record city mismatch");
+
+    // Cleanup
+    check s3Client->deleteObject(testBucketName, jsonKey);
+}
+
+@test:Config {
+    dependsOn: [testGetObjectAsRecord]
+}
+function testGetObjectAsRecordFromXml() returns error? {
+    // Create an XML object
+    xml xmlContent = xml `<root><name>Bob</name><age>25</age><city>LA</city></root>`;
+    string xmlKey = "test-record-object.xml";
+    check s3Client->putObject(testBucketName, xmlKey, xmlContent);
+
+    // Get the object as a typed record using getObject - .xml extension triggers XML parsing
+    XmlPersonRecord response = check s3Client->getObject(testBucketName, xmlKey);
+    test:assertEquals(response.name, "Bob", "XML record name mismatch");
+    test:assertEquals(response.age, "25", "XML record age mismatch");
+    test:assertEquals(response.city, "LA", "XML record city mismatch");
+
+    // Cleanup
+    check s3Client->deleteObject(testBucketName, xmlKey);
+}
+
+@test:Config {
+    dependsOn: [testGetObjectAsRecordFromXml]
+}
+function testGetObjectAsRecordArray() returns error? {
+    // Create CSV content (first row = headers, subsequent rows = data)
     string csvContent = "name,age,city\nAlice,30,NY\nBob,25,LA";
-    string csvKey = "test-csv-object.csv";
+    string csvKey = "test-record-array.csv";
     check s3Client->putObject(testBucketName, csvKey, csvContent);
 
-    // Get the object as CSV using the getObjectAsCsv API
-    // csv:parseBytes treats the first row as headers and returns only the data rows
-    string[][] response = check s3Client->getObjectAsCsv(testBucketName, csvKey);
-    test:assertEquals(response.length(), 2, "Expected 2 data rows");
-    test:assertEquals(response[0][0], "Alice", "CSV row1 col1 mismatch");
-    test:assertEquals(response[0][1], "30", "CSV row1 col2 mismatch");
-    test:assertEquals(response[0][2], "NY", "CSV row1 col3 mismatch");
-    test:assertEquals(response[1][0], "Bob", "CSV row2 col1 mismatch");
-    test:assertEquals(response[1][1], "25", "CSV row2 col2 mismatch");
-    test:assertEquals(response[1][2], "LA", "CSV row2 col3 mismatch");
+    // Get the object as record[] using getObject with record array type inference
+    CsvPersonRecord[] response = check s3Client->getObject(testBucketName, csvKey);
+    test:assertEquals(response.length(), 2, "Expected 2 records");
+    test:assertEquals(response[0].name, "Alice", "Record[0] name mismatch");
+    test:assertEquals(response[0].age, "30", "Record[0] age mismatch");
+    test:assertEquals(response[0].city, "NY", "Record[0] city mismatch");
+    test:assertEquals(response[1].name, "Bob", "Record[1] name mismatch");
+    test:assertEquals(response[1].age, "25", "Record[1] age mismatch");
+    test:assertEquals(response[1].city, "LA", "Record[1] city mismatch");
 
     // Cleanup
     check s3Client->deleteObject(testBucketName, csvKey);
 }
 
 @test:Config {
-    dependsOn: [testGetObjectAsCsv]
+    dependsOn: [testGetObjectAsRecordArray]
+}
+function testGetObjectAsRecordStream() returns error? {
+    // Create a JSON array object
+    json jsonArray = [
+        {"name": "Alice", "age": 30, "city": "NY"},
+        {"name": "Bob", "age": 25, "city": "LA"}
+    ];
+    string jsonKey = "test-record-stream.json";
+    check s3Client->putObject(testBucketName, jsonKey, jsonArray);
+
+    // Get the object as stream<record{}, error?> using getObject
+    stream<PersonRecord, error?> response = check s3Client->getObject(testBucketName, jsonKey);
+
+    PersonRecord[] records = [];
+    check from PersonRecord rec in response
+        do {
+            records.push(rec);
+        };
+
+    test:assertEquals(records.length(), 2, "Expected 2 records from stream");
+    test:assertEquals(records[0].name, "Alice", "Stream record[0] name mismatch");
+    test:assertEquals(records[0].age, 30, "Stream record[0] age mismatch");
+    test:assertEquals(records[1].name, "Bob", "Stream record[1] name mismatch");
+    test:assertEquals(records[1].age, 25, "Stream record[1] age mismatch");
+
+    // Cleanup
+    check s3Client->deleteObject(testBucketName, jsonKey);
+}
+
+@test:Config {
+    dependsOn: [testGetObjectAsRecordStream]
+}
+function testPutRecordArrayGetRecordStream() returns error? {
+    json jsonArray = [
+        {"name": "Alice", "age": 30, "city": "NY"},
+        {"name": "Bob", "age": 25, "city": "LA"}
+    ];
+    string jsonKey = "test-put-arr-get-stream.json";
+    check s3Client->putObject(testBucketName, jsonKey, jsonArray);
+
+    stream<PersonRecord, error?> response = check s3Client->getObject(testBucketName, jsonKey);
+    PersonRecord[] records = [];
+    check from PersonRecord rec in response
+        do {
+            records.push(rec);
+        };
+    test:assertEquals(records.length(), 2, "Expected 2 records from stream");
+    test:assertEquals(records[0].name, "Alice", "Round-trip stream record[0] name mismatch");
+    test:assertEquals(records[1].name, "Bob", "Round-trip stream record[1] name mismatch");
+
+    check s3Client->deleteObject(testBucketName, jsonKey);
+}
+
+@test:Config {
+    dependsOn: [testPutRecordArrayGetRecordStream]
+}
+function testGetObjectAsRecordFromNonJsonExtension() returns error? {
+    json jsonContent = {"name": "Charlie", "age": 40, "city": "SF"};
+    string txtKey = "test-record-nojson-ext.txt";
+    check s3Client->putObject(testBucketName, txtKey, jsonContent);
+
+    PersonRecord response = check s3Client->getObject(testBucketName, txtKey);
+    test:assertEquals(response.name, "Charlie", "Non-json extension record name mismatch");
+    test:assertEquals(response.age, 40, "Non-json extension record age mismatch");
+
+    check s3Client->deleteObject(testBucketName, txtKey);
+}
+
+@test:Config {
+    dependsOn: [testGetObjectAsRecordFromNonJsonExtension]
+}
+function testGetObjectAsRecordWithInvalidContent() returns error? {
+    string invalidKey = "test-invalid-record.json";
+    string invalidContent = "this is not json at all";
+    check s3Client->putObject(testBucketName, invalidKey, invalidContent);
+
+    PersonRecord|Error response = s3Client->getObject(testBucketName, invalidKey);
+    test:assertTrue(response is Error, "Expected an error for invalid record content");
+
+    check s3Client->deleteObject(testBucketName, invalidKey);
+}
+
+@test:Config {
+    dependsOn: [testGetObjectAsRecordWithInvalidContent]
+}
+function testPutAndGetEmptyRecordArray() returns error? {
+    CsvPersonRecord[] empty = [];
+    string csvKey = "test-empty-record-array.csv";
+    check s3Client->putObject(testBucketName, csvKey, empty);
+    byte[] rawContent = check s3Client->getObject(testBucketName, csvKey);
+    test:assertEquals(rawContent.length(), 0, "Empty record array should produce empty content");
+    check s3Client->deleteObject(testBucketName, csvKey);
+}
+
+@test:Config {
+    dependsOn: [testPutAndGetEmptyRecordArray]
 }
 function testGetObjectAsJsonWithInvalidContent() returns error? {
     string invalidJsonKey = "test-invalid-json.txt";
@@ -995,7 +1210,7 @@ function testGetObjectAsJsonWithInvalidContent() returns error? {
     check s3Client->putObject(testBucketName, invalidJsonKey, invalidJsonContent);
 
     // Expect a ProcessingError when parsing invalid JSON
-    json|Error response = s3Client->getObjectAsJson(testBucketName, invalidJsonKey);
+    json|Error response = s3Client->getObject(testBucketName, invalidJsonKey);
     test:assertTrue(response is Error, "Expected a parsing error for invalid JSON content");
 
     // Cleanup
@@ -1011,7 +1226,7 @@ function testGetObjectAsXmlWithInvalidContent() returns error? {
     check s3Client->putObject(testBucketName, invalidXmlKey, invalidXmlContent);
 
     // Expect a ProcessingError when parsing invalid XML
-    xml|Error response = s3Client->getObjectAsXml(testBucketName, invalidXmlKey);
+    xml|Error response = s3Client->getObject(testBucketName, invalidXmlKey);
     test:assertTrue(response is Error, "Expected a parsing error for invalid XML content");
 
     // Cleanup
@@ -1102,7 +1317,7 @@ function testUploadPartAsStream() returns error? {
     check s3Client->completeMultipartUpload(testBucketName, objectKey, streamUploadId, [1], [etag]);
     
     // Verify the uploaded object
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     record {byte[] value;}? chunk = check response.next();
 
     if chunk is record {byte[] value;} {
@@ -1174,7 +1389,7 @@ function testUploadMultiplePartsAsStream() returns error? {
     check s3Client->completeMultipartUpload(testBucketName, objectKey, multiPartUploadId, [1, 2], [etag1, etag2]);
     
     // Verify the uploaded object has the correct size (part1 + part2)
-    stream<byte[], error?> response = check s3Client->getObjectAsStream(testBucketName, objectKey);
+    stream<byte[], error?> response = check s3Client->getObject(testBucketName, objectKey);
     byte[] fullDownloadedContent = [];
     check from byte[] bytes in response
         do {

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -324,6 +324,61 @@ function testPutObjectWithRecordContent() returns error? {
 @test:Config {
     dependsOn: [testCreateBucket]
 }
+function testPutObjectWithRecordContentAsXml() returns error? {
+    string objectKey = "test_record_put.xml";
+    XmlPersonRecord person = {name: "Alice", age: "30", city: "NY"};
+    check s3Client->putObject(testBucketName, objectKey, person);
+
+    // Verify by getting as XML and checking structure
+    xml response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals((response/<name>).data(), "Alice", "XML record name mismatch");
+    test:assertEquals((response/<age>).data(), "30", "XML record age mismatch");
+    test:assertEquals((response/<city>).data(), "NY", "XML record city mismatch");
+
+    // Verify round-trip: get back as record
+    XmlPersonRecord recordResponse = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(recordResponse, person, "XML record round-trip mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectWithRecordContentAsXmlWithNestedPath() returns error? {
+    string objectKey = "data/users/test_record.xml";
+    XmlPersonRecord person = {name: "Bob", age: "25", city: "LA"};
+    check s3Client->putObject(testBucketName, objectKey, person);
+
+    // Root element should be derived from filename ("test_record")
+    XmlPersonRecord recordResponse = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(recordResponse.name, "Bob", "Nested path XML record name mismatch");
+    test:assertEquals(recordResponse.age, "25", "Nested path XML record age mismatch");
+    test:assertEquals(recordResponse.city, "LA", "Nested path XML record city mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
+function testPutObjectWithRecordContentNonXmlExtension() returns error? {
+    // Verify that non-.xml keys still serialize as JSON
+    string objectKey = "test_record_put.txt";
+    PersonRecord person = {name: "Charlie", age: 40, city: "SF"};
+    check s3Client->putObject(testBucketName, objectKey, person);
+
+    // Should be JSON, so we can read as json
+    json response = check s3Client->getObject(testBucketName, objectKey);
+    test:assertEquals(response.name, "Charlie", "Non-XML record name mismatch");
+    test:assertEquals(response.age, 40, "Non-XML record age mismatch");
+
+    check s3Client->deleteObject(testBucketName, objectKey);
+}
+
+@test:Config {
+    dependsOn: [testCreateBucket]
+}
 function testPutObjectWithRecordArrayContent() returns error? {
     string objectKey = "test_record_array_put.csv";
     CsvPersonRecord[] people = [

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -48,6 +48,10 @@ public type Bucket record {
 
 # Represents byte[], string, json and xml
 public type ContentType byte[]|string|json|xml;
+
+# Represents the content types supported for uploading an S3 object.
+public type UploadContent byte[]|string|json|xml|record {}|record {}[]|stream<byte[], error?>|stream<record {}, error?>;
+
 # Represents the types that can be returned when retrieving an S3 object.
 public type RetrievableType byte[]|string|json|xml|record {}|record {}[]|stream<byte[], error?>|stream<record {}, error?>;
 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -48,6 +48,8 @@ public type Bucket record {
 
 # Represents byte[], string, json and xml
 public type ContentType byte[]|string|json|xml;
+# Represents the types that can be returned when retrieving an S3 object.
+public type RetrievableType byte[]|string|json|xml|record {}|record {}[]|stream<byte[], error?>|stream<record {}, error?>;
 
 # Configuration for uploading an object.
 public type PutObjectConfig record {|

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -55,6 +55,16 @@ public type UploadContent byte[]|string|json|xml|record {}|record {}[]|stream<by
 # Represents the types that can be returned when retrieving an S3 object.
 public type RetrievableType byte[]|string|json|xml|record {}|record {}[]|stream<byte[], error?>|stream<record {}, error?>;
 
+# Represents the file format for serializing record content.
+public enum FileFormat {
+    # JSON format
+    JSON,
+    # XML format
+    XML,
+    # CSV format
+    CSV
+}
+
 # Configuration for uploading an object.
 public type PutObjectConfig record {|
     # The MIME type of the content
@@ -79,6 +89,8 @@ public type PutObjectConfig record {|
     string tagging?;
     # Encryption type ("AES256" or "aws:kms")
     string serverSideEncryption?;
+    # The file format to use for serializing record content. Overrides the format inferred from the object key extension
+    FileFormat fileFormat?;
 |};
 
 # Configuration for uploading an object as a stream.
@@ -228,6 +240,8 @@ public type UploadPartConfig record {|
     int contentLength?;
     # MD5 hash of the part content (for data integrity check)
     string contentMD5?;
+    # The file format to use for serializing record content. Overrides the format inferred from the object key extension
+    FileFormat fileFormat?;
 |};
 
 # Configuration for uploading a part as a stream in a multipart upload.

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -89,6 +89,28 @@ isolated function collectRecordStream(stream<record {}, error?> recordStream) re
     return records;
 }
 
+isolated function convertRecordToXml(record {} rec, string objectKey) returns string {
+    // Derive root element name from the object key filename (without extension)
+    string rootName = "root";
+    string key = objectKey;
+    int? lastSlash = key.lastIndexOf("/");
+    if lastSlash is int {
+        key = key.substring(lastSlash + 1);
+    }
+    if key.toLowerAscii().endsWith(".xml") {
+        rootName = key.substring(0, key.length() - 4);
+    }
+
+    string[] parts = [];
+    parts.push(string `<${rootName}>`);
+    foreach [string, anydata] [fieldName, value] in rec.entries() {
+        string strVal = value is () ? "" : value.toString();
+        parts.push(string `<${fieldName}>${strVal}</${fieldName}>`);
+    }
+    parts.push(string `</${rootName}>`);
+    return string:'join("", ...parts);
+}
+
 isolated function convertRecordsToCsv(record {}[] records) returns byte[] {
     if records.length() == 0 {
         return [];

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -14,6 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+const string JSON_EXTENSION = ".json";
+const string XML_EXTENSION = ".xml";
+const string CSV_EXTENSION = ".csv";
 const string CSV_SEPARATOR = ",";
 const string CSV_LINE_SEPARATOR = "\n";
 const string EMPTY_STRING = "";
@@ -97,8 +100,8 @@ isolated function convertRecordToXml(record {} rec, string objectKey) returns st
     if lastSlash is int {
         key = key.substring(lastSlash + 1);
     }
-    if key.toLowerAscii().endsWith(".xml") {
-        rootName = key.substring(0, key.length() - 4);
+    if key.toLowerAscii().endsWith(XML_EXTENSION) {
+        rootName = key.substring(0, key.length() - XML_EXTENSION.length());
     }
 
     string[] parts = [];

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -14,6 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+const string CSV_SEPARATOR = ",";
+const string CSV_LINE_SEPARATOR = "\n";
+const string EMPTY_STRING = "";
+
 # Validates if a bucket name follows AWS naming conventions.
 #
 # + bucketName - The name of the bucket
@@ -51,4 +55,54 @@ isolated function toByteArray(anydata content) returns byte[] {
         return content.toJsonString().toBytes();
     }
     return content.toString().toBytes();
+}
+
+# Collects all chunks from a byte stream into a single byte array.
+#
+# + byteStream - The byte stream to collect
+# + return - The collected bytes or an Error
+isolated function collectByteStream(stream<byte[], error?> byteStream) returns byte[]|Error {
+    byte[] collected = [];
+    error? e = from byte[] chunk in byteStream
+        do {
+            collected.push(...chunk);
+        };
+    if e is error {
+        return error Error("Failed to read byte stream: " + e.message(), e);
+    }
+    return collected;
+}
+
+# Collects all records from a record stream into an array.
+#
+# + recordStream - The record stream to collect
+# + return - The collected records or an Error
+isolated function collectRecordStream(stream<record {}, error?> recordStream) returns record {}[]|Error {
+    record {}[] records = [];
+    error? e = from record {} rec in recordStream
+        do {
+            records.push(rec);
+        };
+    if e is error {
+        return error Error("Failed to read record stream: " + e.message(), e);
+    }
+    return records;
+}
+
+isolated function convertRecordsToCsv(record {}[] records) returns byte[] {
+    if records.length() == 0 {
+        return [];
+    }
+    string[] headers = records[0].keys();
+    string[] lines = [];
+    lines.push(string:'join(CSV_SEPARATOR, ...headers));
+    foreach record {} rec in records {
+        string[] values = [];
+        foreach string header in headers {
+            anydata val = rec[header];
+            values.push(val is () ? EMPTY_STRING : val.toString());
+        }
+        lines.push(string:'join(CSV_SEPARATOR, ...values));
+    }
+    return string:'join(CSV_LINE_SEPARATOR, ...lines).toBytes();
 }

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -108,6 +108,11 @@ isolated function convertRecordToXml(record {} rec, string objectKey) returns st
     parts.push(string `<${rootName}>`);
     foreach [string, anydata] [fieldName, value] in rec.entries() {
         string strVal = value is () ? "" : value.toString();
+        strVal = re `&`.replaceAll(strVal, "&amp;");
+        strVal = re `<`.replaceAll(strVal, "&lt;");
+        strVal = re `>`.replaceAll(strVal, "&gt;");
+        strVal = re `"`.replaceAll(strVal, "&quot;");
+        strVal = re `'`.replaceAll(strVal, "&apos;");
         parts.push(string `<${fieldName}>${strVal}</${fieldName}>`);
     }
     parts.push(string `</${rootName}>`);
@@ -125,7 +130,12 @@ isolated function convertRecordsToCsv(record {}[] records) returns byte[] {
         string[] values = [];
         foreach string header in headers {
             anydata val = rec[header];
-            values.push(val is () ? EMPTY_STRING : val.toString());
+            string strVal = val is () ? EMPTY_STRING : val.toString();
+            if strVal.includes(CSV_SEPARATOR) || strVal.includes("\"") ||
+                    strVal.includes("\n") || strVal.includes("\r") {
+                strVal = "\"" + re `"`.replaceAll(strVal, "\"\"") + "\"";
+            }
+            values.push(strVal);
         }
         lines.push(string:'join(CSV_SEPARATOR, ...values));
     }

--- a/changelog.md
+++ b/changelog.md
@@ -13,5 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Updated `ConnectionConfig` to use the shared `auth:AuthConfig` from `ballerinax/aws.auth` and `aws:Region` from `ballerinax/aws` for authentication and region configuration
-- Revised object creation and retrieval APIs with more specific method variants
+- Replaced `getObject`, `getObjectAsStream`, `getObjectAsText`, `getObjectAsJson`, `getObjectAsXml`, and `getObjectAsCsv` with a single `getObject` method that supports compile-time type inference via `typedesc`
+- The unified `getObject` method supports `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`, `stream<byte[], error?>`, and `stream<record {}, error?>` as target types
+- For `record {}`, the object key's file extension determines parsing (`.xml` for XML, others default to JSON)
+- For `record {}[]`, the content is parsed as CSV with the first row treated as headers
+- Expanded `putObject` to accept `record {}`, `record {}[]`, `stream<byte[], error?>`, and `stream<record {}, error?>` in addition to the existing `byte[]`, `string`, `json`, and `xml` types
+- `record {}` content is serialized as JSON; `record {}[]` and `stream<record {}, error?>` content is serialized as CSV
 - Introduced distinct error types and restructured configuration records

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `ConnectionConfig` to use the shared `auth:AuthConfig` from `ballerinax/aws.auth` and `aws:Region` from `ballerinax/aws` for authentication and region configuration
 - Replaced `getObject`, `getObjectAsStream`, `getObjectAsText`, `getObjectAsJson`, `getObjectAsXml`, and `getObjectAsCsv` with a single `getObject` method that supports compile-time type inference via `typedesc`
 - The unified `getObject` method supports `byte[]`, `string`, `json`, `xml`, `record {}`, `record {}[]`, `stream<byte[], error?>`, and `stream<record {}, error?>` as target types
-- For `record {}`, the object key's file extension determines parsing (`.xml` for XML, others default to JSON)
+- For `record {}`, the object key must end with `.json` or `.xml` (`.json` for JSON parsing, `.xml` for XML parsing)
 - For `record {}[]`, the content is parsed as CSV with the first row treated as headers
 - Expanded `putObject` to accept `record {}`, `record {}[]`, `stream<byte[], error?>`, and `stream<record {}, error?>` in addition to the existing `byte[]`, `string`, `json`, and `xml` types
 - `record {}` content is serialized as JSON; `record {}[]` and `stream<record {}, error?>` content is serialized as CSV

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -162,6 +162,12 @@ public class NativeClientAdaptor {
     private static final String JSON_EXTENSION = ".json";
     private static final String XML_EXTENSION = ".xml";
     private static final String CSV_EXTENSION = ".csv";
+    private static final String DISALLOW_DOCTYPE_DECL =
+            "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String EXTERNAL_GENERAL_ENTITIES =
+            "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES =
+            "http://xml.org/sax/features/external-parameter-entities";
 
     private static Optional<String> getStringConfig(BMap<BString, Object> config, String key) {
         if (config.containsKey(StringUtils.fromString(key))) {
@@ -1211,8 +1217,14 @@ public class NativeClientAdaptor {
         try {
             if (lowerKey.endsWith(XML_EXTENSION)) {
                 // Parse XML using Java DOM and build a flat map from the root element's children
-                javax.xml.parsers.DocumentBuilder builder =
-                        javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                javax.xml.parsers.DocumentBuilderFactory dbf =
+                        javax.xml.parsers.DocumentBuilderFactory.newInstance();
+                dbf.setFeature(DISALLOW_DOCTYPE_DECL, true);
+                dbf.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+                dbf.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+                dbf.setXIncludeAware(false);
+                dbf.setExpandEntityReferences(false);
+                javax.xml.parsers.DocumentBuilder builder = dbf.newDocumentBuilder();
                 org.w3c.dom.Document doc = builder.parse(
                         new java.io.ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
                 org.w3c.dom.Element root = doc.getDocumentElement();

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -21,15 +21,24 @@ import io.ballerina.lib.aws.auth.ProviderFactory;
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.PredefinedTypes;
+import io.ballerina.runtime.api.types.StreamType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.TypeTags;
 import io.ballerina.runtime.api.values.BStream;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.utils.ValueUtils;
+import io.ballerina.runtime.api.utils.XmlUtils;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -72,6 +81,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -148,6 +158,7 @@ public class NativeClientAdaptor {
     public static final BString HTTP_METHOD = StringUtils.fromString("httpMethod");
     public static final String GET = "GET";
     public static final String PUT = "PUT";
+    private static final String RECORD_STREAM_ITERATOR = "RecordStreamIterator";
 
     private static Optional<String> getStringConfig(BMap<BString, Object> config, String key) {
         if (config.containsKey(StringUtils.fromString(key))) {
@@ -1052,5 +1063,257 @@ public class NativeClientAdaptor {
 
         PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
         return presignedRequest.url().toString();
+    }
+
+    public static Object getObjectWithType(Environment env, BObject clientObj, BString bucket, BString key,
+            BTypedesc targetType, BMap<BString, Object> config) {
+
+        Type type = TypeUtils.getReferredType(targetType.getDescribingType());
+        int tag = type.getTag();
+
+        if (tag == TypeTags.STREAM_TAG) {
+            return handleStreamType(env, clientObj, bucket, key, config, (StreamType) type);
+        }
+
+        Object bytesResult = getObject(clientObj, bucket, key, config);
+        if (bytesResult instanceof BError) {
+            return bytesResult;
+        }
+        BArray bytesArray = (BArray) bytesResult;
+
+        return convertBytes(env, bytesArray, key.getValue(), type);
+    }
+
+    private static Object handleStreamType(Environment env, BObject clientObj, BString bucket, BString key,
+            BMap<BString, Object> config, StreamType streamType) {
+
+        Type constraintType = TypeUtils.getReferredType(streamType.getConstrainedType());
+        if (constraintType.getTag() == TypeTags.ARRAY_TAG
+                && isArrayOfBytes((ArrayType) constraintType)) {
+            Object result = getObjectAsStream(env, clientObj, bucket, key, config);
+            if (result instanceof BError) {
+                return result;
+            }
+            BObject iteratorObj = (BObject) result;
+            return ValueCreator.createStreamValue(streamType, iteratorObj);
+        }
+        Object bytesResult = getObject(clientObj, bucket, key, config);
+        if (bytesResult instanceof BError) {
+            return bytesResult;
+        }
+        BArray bytesArray = (BArray) bytesResult;
+        String content;
+        try {
+            content = new String(bytesArray.getBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return ErrorCreator.createError("Failed to convert bytes to string: " + e.getMessage());
+        }
+
+        Object jsonValue;
+        try {
+            jsonValue = JsonUtils.parse(content);
+        } catch (BError e) {
+            return ErrorCreator.createError("Failed to parse JSON for record stream: " + e.getMessage(), e);
+        } catch (Exception e) {
+            return ErrorCreator.createError("Failed to parse JSON for record stream: " + e.getMessage());
+        }
+
+        if (!(jsonValue instanceof BArray jsonArray)) {
+            return ErrorCreator.createError("Expected a JSON array for streaming records");
+        }
+
+        List<BMap<BString, Object>> records = new ArrayList<>();
+        for (int i = 0; i < jsonArray.size(); i++) {
+            Object element = jsonArray.get(i);
+            try {
+                Object converted = ValueUtils.convert(element, constraintType);
+                @SuppressWarnings("unchecked")
+                BMap<BString, Object> record = (BMap<BString, Object>) converted;
+                records.add(record);
+            } catch (BError e) {
+                return ErrorCreator.createError("Failed to convert JSON element to record: " + e.getMessage());
+            } catch (Exception e) {
+                return ErrorCreator.createError("Failed to convert JSON element to record: " + e.getMessage());
+            }
+        }
+
+        BObject iteratorObj = ValueCreator.createObjectValue(env.getCurrentModule(), RECORD_STREAM_ITERATOR,
+                toRecordArray(records, constraintType));
+        return ValueCreator.createStreamValue(streamType, iteratorObj);
+    }
+
+    private static Object convertBytes(Environment env, BArray bytes, String objectKey, Type targetType) {
+        int tag = targetType.getTag();
+        if (tag == TypeTags.ARRAY_TAG && isArrayOfBytes((ArrayType) targetType)) {
+            return bytes;
+        }
+
+        String content;
+        try {
+            content = new String(bytes.getBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return ErrorCreator.createError("Failed to convert bytes to string: " + e.getMessage());
+        }
+
+        switch (tag) {
+            case TypeTags.STRING_TAG:
+                return StringUtils.fromString(content);
+
+            case TypeTags.XML_TAG:
+            case TypeTags.XML_ELEMENT_TAG:
+                try {
+                    return XmlUtils.parse(content);
+                } catch (BError e) {
+                    return ErrorCreator.createError("Failed to parse XML: " + e.getMessage(), e);
+                } catch (Exception e) {
+                    return ErrorCreator.createError("Failed to parse XML: " + e.getMessage());
+                }
+
+            case TypeTags.JSON_TAG:
+            case TypeTags.UNION_TAG:
+                try {
+                    return JsonUtils.parse(content);
+                } catch (BError e) {
+                    return ErrorCreator.createError("Failed to parse JSON: " + e.getMessage(), e);
+                } catch (Exception e) {
+                    return ErrorCreator.createError("Failed to parse JSON: " + e.getMessage());
+                }
+
+            case TypeTags.RECORD_TYPE_TAG:
+            case TypeTags.MAP_TAG:
+                return convertToRecord(content, objectKey, targetType);
+
+            case TypeTags.ARRAY_TAG:
+                ArrayType arrayType = (ArrayType) targetType;
+                Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
+                if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                    return convertCsvToRecords(content, elementType, arrayType);
+                }
+                try {
+                    Object jsonValue = JsonUtils.parse(content);
+                    return ValueUtils.convert(jsonValue, targetType);
+                } catch (BError e) {
+                    return ErrorCreator.createError("Failed to parse array: " + e.getMessage(), e);
+                } catch (Exception e) {
+                    return ErrorCreator.createError("Failed to parse array: " + e.getMessage());
+                }
+
+            default:
+                return ErrorCreator.createError("Unsupported target type: " + targetType);
+        }
+    }
+
+    private static Object convertToRecord(String content, String objectKey, Type targetType) {
+        String lowerKey = objectKey.toLowerCase();
+        try {
+            if (lowerKey.endsWith(".xml")) {
+                // Parse XML using Java DOM and build a flat map from the root element's children
+                javax.xml.parsers.DocumentBuilder builder =
+                        javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                org.w3c.dom.Document doc = builder.parse(
+                        new java.io.ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+                org.w3c.dom.Element root = doc.getDocumentElement();
+                org.w3c.dom.NodeList children = root.getChildNodes();
+
+                BMap<BString, Object> map = ValueCreator.createMapValue();
+                for (int i = 0; i < children.getLength(); i++) {
+                    org.w3c.dom.Node child = children.item(i);
+                    if (child.getNodeType() == org.w3c.dom.Node.ELEMENT_NODE) {
+                        map.put(StringUtils.fromString(child.getNodeName()),
+                                StringUtils.fromString(child.getTextContent()));
+                    }
+                }
+                return ValueUtils.convert(map, targetType);
+            } else {
+                Object jsonValue = JsonUtils.parse(content);
+                return ValueUtils.convert(jsonValue, targetType);
+            }
+        } catch (BError e) {
+            return ErrorCreator.createError("Failed to convert to record: " + e.getMessage(), e);
+        } catch (Exception e) {
+            return ErrorCreator.createError("Failed to convert to record: " + e.getMessage());
+        }
+    }
+
+    private static Object convertCsvToRecords(String content, Type elementType, ArrayType arrayType) {
+        try {
+            String[] lines = content.split("\r?\n");
+            if (lines.length < 1) {
+                return ErrorCreator.createError("CSV content is empty");
+            }
+
+            String[] headers = parseCsvLine(lines[0]);
+            for (int i = 0; i < headers.length; i++) {
+                headers[i] = headers[i].trim();
+            }
+
+            List<BMap<BString, Object>> records = new ArrayList<>();
+            for (int i = 1; i < lines.length; i++) {
+                String line = lines[i].trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+                String[] values = parseCsvLine(line);
+
+                BMap<BString, Object> jsonMap = ValueCreator.createMapValue();
+                for (int j = 0; j < headers.length; j++) {
+                    String value = j < values.length ? values[j].trim() : "";
+                    jsonMap.put(StringUtils.fromString(headers[j]), StringUtils.fromString(value));
+                }
+
+                Object converted = ValueUtils.convert(jsonMap, elementType);
+                @SuppressWarnings("unchecked")
+                BMap<BString, Object> record = (BMap<BString, Object>) converted;
+                records.add(record);
+            }
+            return toRecordArray(records, elementType);
+        } catch (BError e) {
+            return ErrorCreator.createError("Failed to parse CSV: " + e.getMessage(), e);
+        } catch (Exception e) {
+            return ErrorCreator.createError("Failed to parse CSV: " + e.getMessage());
+        }
+    }
+
+    private static String[] parseCsvLine(String line) {
+        List<String> fields = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        current.append('"');
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    current.append(c);
+                }
+            } else {
+                if (c == '"') {
+                    inQuotes = true;
+                } else if (c == ',') {
+                    fields.add(current.toString());
+                    current = new StringBuilder();
+                } else {
+                    current.append(c);
+                }
+            }
+        }
+        fields.add(current.toString());
+        return fields.toArray(new String[0]);
+    }
+
+    private static boolean isArrayOfBytes(ArrayType arrayType) {
+        Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
+        return elementType.getTag() == TypeTags.BYTE_TAG;
+    }
+
+    private static BArray toRecordArray(List<BMap<BString, Object>> records, Type elementType) {
+        BMap<BString, Object>[] arr = records.toArray(new BMap[0]);
+        return ValueCreator.createArrayValue(arr, TypeCreator.createArrayType(elementType));
     }
 }

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -159,6 +159,9 @@ public class NativeClientAdaptor {
     public static final String GET = "GET";
     public static final String PUT = "PUT";
     private static final String RECORD_STREAM_ITERATOR = "RecordStreamIterator";
+    private static final String JSON_EXTENSION = ".json";
+    private static final String XML_EXTENSION = ".xml";
+    private static final String CSV_EXTENSION = ".csv";
 
     private static Optional<String> getStringConfig(BMap<BString, Object> config, String key) {
         if (config.containsKey(StringUtils.fromString(key))) {
@@ -1097,6 +1100,11 @@ public class NativeClientAdaptor {
             BObject iteratorObj = (BObject) result;
             return ValueCreator.createStreamValue(streamType, iteratorObj);
         }
+        if (!key.getValue().toLowerCase().endsWith(CSV_EXTENSION)) {
+            return ErrorCreator.createError(
+                    "stream<record {}, error?> target type requires a '.csv' file extension in the object key");
+        }
+
         Object bytesResult = getObject(clientObj, bucket, key, config);
         if (bytesResult instanceof BError) {
             return bytesResult;
@@ -1109,32 +1117,18 @@ public class NativeClientAdaptor {
             return ErrorCreator.createError("Failed to convert bytes to string: " + e.getMessage());
         }
 
-        Object jsonValue;
-        try {
-            jsonValue = JsonUtils.parse(content);
-        } catch (BError e) {
-            return ErrorCreator.createError("Failed to parse JSON for record stream: " + e.getMessage(), e);
-        } catch (Exception e) {
-            return ErrorCreator.createError("Failed to parse JSON for record stream: " + e.getMessage());
+        ArrayType arrayType = TypeCreator.createArrayType(constraintType);
+        Object csvResult = convertCsvToRecords(content, constraintType, arrayType);
+        if (csvResult instanceof BError) {
+            return csvResult;
         }
-
-        if (!(jsonValue instanceof BArray jsonArray)) {
-            return ErrorCreator.createError("Expected a JSON array for streaming records");
-        }
+        BArray csvArray = (BArray) csvResult;
 
         List<BMap<BString, Object>> records = new ArrayList<>();
-        for (int i = 0; i < jsonArray.size(); i++) {
-            Object element = jsonArray.get(i);
-            try {
-                Object converted = ValueUtils.convert(element, constraintType);
-                @SuppressWarnings("unchecked")
-                BMap<BString, Object> record = (BMap<BString, Object>) converted;
-                records.add(record);
-            } catch (BError e) {
-                return ErrorCreator.createError("Failed to convert JSON element to record: " + e.getMessage());
-            } catch (Exception e) {
-                return ErrorCreator.createError("Failed to convert JSON element to record: " + e.getMessage());
-            }
+        for (int i = 0; i < csvArray.size(); i++) {
+            @SuppressWarnings("unchecked")
+            BMap<BString, Object> record = (BMap<BString, Object>) csvArray.get(i);
+            records.add(record);
         }
 
         BObject iteratorObj = ValueCreator.createObjectValue(env.getCurrentModule(), RECORD_STREAM_ITERATOR,
@@ -1181,12 +1175,21 @@ public class NativeClientAdaptor {
 
             case TypeTags.RECORD_TYPE_TAG:
             case TypeTags.MAP_TAG:
+                String lowerKeyRec = objectKey.toLowerCase();
+                if (!lowerKeyRec.endsWith(JSON_EXTENSION) && !lowerKeyRec.endsWith(XML_EXTENSION)) {
+                    return ErrorCreator.createError(
+                            "record {} target type requires a '.json' or '.xml' file extension in the object key");
+                }
                 return convertToRecord(content, objectKey, targetType);
 
             case TypeTags.ARRAY_TAG:
                 ArrayType arrayType = (ArrayType) targetType;
                 Type elementType = TypeUtils.getReferredType(arrayType.getElementType());
                 if (elementType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+                    if (!objectKey.toLowerCase().endsWith(CSV_EXTENSION)) {
+                        return ErrorCreator.createError(
+                                "record {}[] target type requires a '.csv' file extension in the object key");
+                    }
                     return convertCsvToRecords(content, elementType, arrayType);
                 }
                 try {
@@ -1206,7 +1209,7 @@ public class NativeClientAdaptor {
     private static Object convertToRecord(String content, String objectKey, Type targetType) {
         String lowerKey = objectKey.toLowerCase();
         try {
-            if (lowerKey.endsWith(".xml")) {
+            if (lowerKey.endsWith(XML_EXTENSION)) {
                 // Parse XML using Java DOM and build a flat map from the root element's children
                 javax.xml.parsers.DocumentBuilder builder =
                         javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder();

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -19,6 +19,7 @@
 module io.ballerina.lib.aws.s3 {
     requires io.ballerina.runtime;
     requires io.ballerina.lib.aws.auth;
+    requires java.xml;
     requires software.amazon.awssdk.services.s3;
     requires software.amazon.awssdk.auth;
     requires software.amazon.awssdk.core;


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Revamped object retrieval and upload APIs with unified `getObject(...)` and `putObject(...)` methods.
- Added support for inferred content types, byte streams, records, metadata, and content length.
- Updated multipart upload and object listing behavior.
- Moved authentication and region types to shared AWS modules.
- Added endpoint configuration and default credential provider support.
- Added directory bucket types and session configuration.
- Updated native client handling, stream processing, dependencies, package metadata, examples, tests, and documentation.
- Documented migration changes and alternative authentication methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->