### PR TITLE
Add support for directory bucket APIs

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerinax"
 name = "aws.s3"
-version = "5.0.0"
+version = "4.0.0"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Cloud/Object Storage", "Cost/Paid", "Vendor/Amazon", "Area/Storage & File Management", "Type/Connector"]
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib.aws.s3"
 artifactId = "aws.s3-native"
-version = "5.0.0"
-path = "../native/build/libs/aws.s3-native-5.0.0-SNAPSHOT.jar"
+version = "4.0.0"
+path = "../native/build/libs/aws.s3-native-4.0.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "software.amazon.awssdk"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -66,7 +66,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "aws"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -388,7 +388,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "aws.s3"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
 	{org = "ballerina", name = "data.csv"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -432,6 +432,54 @@ public isolated client class Client {
         'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
     } external;
 
+    # Creates an S3 directory bucket (S3 Express One Zone).
+    # Directory bucket names must follow the format: `bucket-base-name--azid--x-s3`
+    # (e.g., `my-bucket--usw2-az1--x-s3`).
+    #
+    # + bucketName - The name of the directory bucket
+    # + config - Directory bucket configuration including availability zone
+    # + return - An Error if bucket creation fails
+    @display {label: "Create Directory Bucket"}
+    remote isolated function createDirectoryBucket(@display {label: "Bucket Name"} string bucketName,
+            *CreateDirectoryBucketConfig config) returns Error? = @java:Method {
+        name: "createDirectoryBucket",
+        'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
+    } external;
+
+    # Lists all S3 directory buckets (S3 Express One Zone) in the AWS account.
+    #
+    # + config - Optional listing configuration
+    # + return - List of directory buckets or an Error
+    @display {label: "List Directory Buckets"}
+    remote isolated function listDirectoryBuckets(*ListDirectoryBucketsConfig config)
+            returns @display {label: "Directory Buckets"} ListDirectoryBucketsResponse|Error {
+        json result = check nativeListDirectoryBuckets(self, config);
+        ListDirectoryBucketsResponse|error response = result.fromJsonWithType();
+        if response is error {
+            return error Error(response.message(), response);
+        }
+        return response;
+    }
+
+    # Creates a session for a directory bucket (S3 Express One Zone).
+    # The returned session credentials can be used for data plane operations
+    # on the directory bucket.
+    #
+    # + bucketName - The name of the directory bucket
+    # + config - Optional session configuration
+    # + return - Session credentials or an Error
+    @display {label: "Create Session"}
+    remote isolated function createSession(@display {label: "Bucket Name"} string bucketName,
+            *CreateSessionConfig config)
+            returns @display {label: "Session Credentials"} SessionCredentials|Error {
+        json result = check nativeCreateSession(self, bucketName, config);
+        SessionCredentials|error credentials = result.fromJsonWithType();
+        if credentials is error {
+            return error Error(credentials.message(), credentials);
+        }
+        return credentials;
+    }
+
     # Closes the underlying S3 client and releases resources.
     #
     # + return - An Error if closing fails
@@ -483,5 +531,15 @@ isolated function nativeHeadObject(Client self, string bucket, string key, HeadO
 
 isolated function nativeUploadPart(Client self, string bucket, string key, string uploadId, int partNumber, byte[] content, UploadPartConfig config) returns string|Error = @java:Method {
     name: "uploadPart",
+    'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
+} external;
+
+isolated function nativeListDirectoryBuckets(Client self, ListDirectoryBucketsConfig config) returns json|Error = @java:Method {
+    name: "listDirectoryBuckets",
+    'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
+} external;
+
+isolated function nativeCreateSession(Client self, string bucket, CreateSessionConfig config) returns json|Error = @java:Method {
+    name: "createSession",
     'class: "io.ballerina.lib.aws.s3.NativeClientAdaptor"
 } external;

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -249,6 +249,8 @@ public type S3Object record {|
 public type ListObjectsResponse record {|
     # List of objects found
     S3Object[] objects;
+    # Common prefixes when a delimiter is used (e.g., sub-folder paths)
+    string[] commonPrefixes?;
     # Number of objects returned
     int count;
     # True if there are more results (use nextContinuationToken to get them)

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -332,3 +332,53 @@ public enum HttpMethod {
     # HTTP PUT method
     PUT = "PUT"
 }
+
+# Configuration for creating a directory bucket (S3 Express One Zone).
+public type CreateDirectoryBucketConfig record {|
+    # The availability zone ID for the bucket (e.g., "use1-az4", "usw2-az1")
+    string availabilityZoneId;
+    # The data redundancy for the bucket
+    DataRedundancy dataRedundancy = SINGLE_AVAILABILITY_ZONE;
+|};
+
+# Configuration for listing directory buckets.
+public type ListDirectoryBucketsConfig record {|
+    # Maximum number of directory buckets to return
+    int maxDirectoryBuckets?;
+    # Token to get the next page of results
+    string continuationToken?;
+|};
+
+# Response from listing directory buckets.
+public type ListDirectoryBucketsResponse record {|
+    # List of directory buckets found
+    DirectoryBucket[] buckets;
+    # Token to get the next page of results
+    string nextContinuationToken?;
+|};
+
+# Represents an S3 directory bucket (S3 Express One Zone).
+public type DirectoryBucket record {|
+    # The name of the directory bucket
+    string name;
+    # The creation date of the bucket
+    string creationDate;
+|};
+
+# Configuration for creating a session on a directory bucket.
+public type CreateSessionConfig record {|
+    # The session mode (ReadOnly or ReadWrite)
+    SessionMode sessionMode = READ_WRITE;
+|};
+
+# Represents credentials returned from a directory bucket session.
+public type SessionCredentials record {|
+    # The access key ID
+    string accessKeyId;
+    # The secret access key
+    string secretAccessKey;
+    # The session token
+    string sessionToken;
+    # The expiration time of the session
+    string expiration;
+|};

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -324,7 +324,13 @@ public enum StorageClass {
     # Archive with instant retrieval (min 90 days)
     GLACIER_IR = "GLACIER_IR",
     # Lowest cost archive, retrieval takes hours (min 180 days)
-    DEEP_ARCHIVE = "DEEP_ARCHIVE"
+    DEEP_ARCHIVE = "DEEP_ARCHIVE",
+    # Single-AZ high-performance storage for directory buckets (S3 Express One Zone)
+    EXPRESS_ONEZONE = "EXPRESS_ONEZONE",
+    # Storage class for data stored on AWS Snowball devices
+    SNOW = "SNOW",
+    # Storage class for data stored on AWS Outposts
+    OUTPOSTS = "OUTPOSTS"
 }
 
 # HTTP methods for presigned URLs.
@@ -333,6 +339,20 @@ public enum HttpMethod {
     GET = "GET",
     # HTTP PUT method
     PUT = "PUT"
+}
+
+# Data redundancy options for directory buckets.
+public enum DataRedundancy {
+    # Single availability zone redundancy
+    SINGLE_AVAILABILITY_ZONE = "SingleAvailabilityZone"
+}
+
+# Session mode options for directory bucket sessions.
+public enum SessionMode {
+    # Read-only access
+    READ_ONLY = "ReadOnly",
+    # Read-write access
+    READ_WRITE = "ReadWrite"
 }
 
 # Configuration for creating a directory bucket (S3 Express One Zone).

--- a/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
+++ b/native/src/main/java/io/ballerina/lib/aws/s3/NativeClientAdaptor.java
@@ -59,12 +59,23 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.s3.model.BucketInfo;
+import software.amazon.awssdk.services.s3.model.BucketType;
+import software.amazon.awssdk.services.s3.model.DataRedundancy;
+import software.amazon.awssdk.services.s3.model.LocationInfo;
+import software.amazon.awssdk.services.s3.model.LocationType;
+import software.amazon.awssdk.services.s3.model.ListDirectoryBucketsRequest;
+import software.amazon.awssdk.services.s3.model.ListDirectoryBucketsResponse;
+import software.amazon.awssdk.services.s3.model.CreateSessionRequest;
+import software.amazon.awssdk.services.s3.model.CreateSessionResponse;
+import software.amazon.awssdk.services.s3.model.SessionCredentials;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -134,6 +145,7 @@ public class NativeClientAdaptor {
     public static final String EMPTY_STRING = "";
     public static final String STANDARD = "STANDARD";
     public static final BString OBJECTS = StringUtils.fromString("objects");
+    public static final BString COMMON_PREFIXES = StringUtils.fromString("commonPrefixes");
     public static final BString COUNT = StringUtils.fromString("count");
     public static final BString IS_TRUNCATED = StringUtils.fromString("isTruncated");
     public static final BString NEXT_CONTINUATION_TOKEN = StringUtils.fromString("nextContinuationToken");
@@ -148,6 +160,15 @@ public class NativeClientAdaptor {
     public static final BString HTTP_METHOD = StringUtils.fromString("httpMethod");
     public static final String GET = "GET";
     public static final String PUT = "PUT";
+    public static final String AVAILABILITY_ZONE_ID = "availabilityZoneId";
+    public static final String DATA_REDUNDANCY = "dataRedundancy";
+    public static final String MAX_DIRECTORY_BUCKETS = "maxDirectoryBuckets";
+    public static final String SESSION_MODE = "sessionMode";
+    public static final BString BUCKETS = StringUtils.fromString("buckets");
+    public static final BString ACCESS_KEY_ID_RESPONSE = StringUtils.fromString("accessKeyId");
+    public static final BString SECRET_ACCESS_KEY_RESPONSE = StringUtils.fromString("secretAccessKey");
+    public static final BString SESSION_TOKEN_RESPONSE = StringUtils.fromString("sessionToken");
+    public static final BString EXPIRATION = StringUtils.fromString("expiration");
 
     private static Optional<String> getStringConfig(BMap<BString, Object> config, String key) {
         if (config.containsKey(StringUtils.fromString(key))) {
@@ -647,6 +668,17 @@ public class NativeClientAdaptor {
                     TypeCreator.createArrayType(PredefinedTypes.TYPE_JSON));
 
             result.put(OBJECTS, objectsArray);
+
+            List<CommonPrefix> commonPrefixes = response.commonPrefixes();
+            if (commonPrefixes != null && !commonPrefixes.isEmpty()) {
+                BArray prefixArray = ValueCreator.createArrayValue(
+                        TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
+                for (int i = 0; i < commonPrefixes.size(); i++) {
+                    prefixArray.append(StringUtils.fromString(commonPrefixes.get(i).prefix()));
+                }
+                result.put(COMMON_PREFIXES, prefixArray);
+            }
+
             result.put(COUNT, (long) size);
             result.put(IS_TRUNCATED, Boolean.TRUE.equals(response.isTruncated()));
 
@@ -943,6 +975,118 @@ public class NativeClientAdaptor {
 
             s3.abortMultipartUpload(request);
             return null;
+        } catch (Exception e) {
+            return ErrorCreator.createError(e);
+        }
+    }
+
+    public static Object createDirectoryBucket(BObject clientObj, BString bucketName, BMap<BString, Object> config) {
+        Object clientOrError = getClient(clientObj);
+        if (clientOrError instanceof BError) {
+            return clientOrError;
+        }
+        @SuppressWarnings("resource")
+        S3Client s3 = (S3Client) clientOrError;
+        String bucket = bucketName.getValue();
+        try {
+            Optional<String> azId = getStringConfig(config, AVAILABILITY_ZONE_ID);
+            if (azId.isEmpty()) {
+                return ErrorCreator.createError("availabilityZoneId is required for creating a directory bucket");
+            }
+
+            String dataRedundancy = getStringConfig(config, DATA_REDUNDANCY).orElse("SingleAvailabilityZone");
+
+            CreateBucketConfiguration bucketConfig = CreateBucketConfiguration.builder()
+                    .bucket(BucketInfo.builder()
+                            .dataRedundancy(DataRedundancy.fromValue(dataRedundancy))
+                            .type(BucketType.DIRECTORY)
+                            .build())
+                    .location(LocationInfo.builder()
+                            .name(azId.get())
+                            .type(LocationType.AVAILABILITY_ZONE)
+                            .build())
+                    .build();
+
+            CreateBucketRequest request = CreateBucketRequest.builder()
+                    .bucket(bucket)
+                    .createBucketConfiguration(bucketConfig)
+                    .build();
+
+            s3.createBucket(request);
+            return null;
+        } catch (Exception e) {
+            return ErrorCreator.createError(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Object listDirectoryBuckets(BObject clientObj, BMap<BString, Object> config) {
+        Object clientOrError = getClient(clientObj);
+        if (clientOrError instanceof BError) {
+            return clientOrError;
+        }
+        @SuppressWarnings("resource")
+        S3Client s3 = (S3Client) clientOrError;
+        try {
+            ListDirectoryBucketsRequest.Builder builder = ListDirectoryBucketsRequest.builder();
+            applyIntConfig(config, MAX_DIRECTORY_BUCKETS, builder::maxDirectoryBuckets);
+            applyStringConfig(config, CONTINUATION_TOKEN, builder::continuationToken);
+
+            ListDirectoryBucketsResponse response = s3.listDirectoryBuckets(builder.build());
+            MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_JSON);
+            BMap<BString, Object> result = ValueCreator.createMapValue(mapType);
+
+            List<Bucket> buckets = response.buckets();
+            BMap<BString, Object>[] bBuckets = new BMap[buckets.size()];
+
+            for (int i = 0; i < buckets.size(); i++) {
+                Bucket b = buckets.get(i);
+                BMap<BString, Object> bucketRecord = ValueCreator.createMapValue(mapType);
+                bucketRecord.put(NAME, StringUtils.fromString(b.name()));
+                Instant creationDate = b.creationDate();
+                String creationDateStr = creationDate != null ? creationDate.toString() : EMPTY_STRING;
+                bucketRecord.put(CREATION_DATE, StringUtils.fromString(creationDateStr));
+                bBuckets[i] = bucketRecord;
+            }
+
+            result.put(BUCKETS, ValueCreator.createArrayValue(bBuckets,
+                    TypeCreator.createArrayType(PredefinedTypes.TYPE_JSON)));
+
+            if (response.continuationToken() != null) {
+                result.put(NEXT_CONTINUATION_TOKEN, StringUtils.fromString(response.continuationToken()));
+            }
+
+            return result;
+        } catch (Exception e) {
+            return ErrorCreator.createError(e);
+        }
+    }
+
+    public static Object createSession(BObject clientObj, BString bucket, BMap<BString, Object> config) {
+        Object clientOrError = getClient(clientObj);
+        if (clientOrError instanceof BError) {
+            return clientOrError;
+        }
+        @SuppressWarnings("resource")
+        S3Client s3 = (S3Client) clientOrError;
+        try {
+            CreateSessionRequest.Builder builder = CreateSessionRequest.builder()
+                    .bucket(bucket.getValue());
+
+            applyStringConfig(config, SESSION_MODE, builder::sessionMode);
+
+            CreateSessionResponse response = s3.createSession(builder.build());
+            SessionCredentials creds = response.credentials();
+
+            MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_JSON);
+            BMap<BString, Object> result = ValueCreator.createMapValue(mapType);
+
+            result.put(ACCESS_KEY_ID_RESPONSE, StringUtils.fromString(creds.accessKeyId()));
+            result.put(SECRET_ACCESS_KEY_RESPONSE, StringUtils.fromString(creds.secretAccessKey()));
+            result.put(SESSION_TOKEN_RESPONSE, StringUtils.fromString(creds.sessionToken()));
+            result.put(EXPIRATION, StringUtils.fromString(creds.expiration().toString()));
+
+            return result;
         } catch (Exception e) {
             return ErrorCreator.createError(e);
         }


### PR DESCRIPTION
## Purpose

Fixes:
https://github.com/ballerina-platform/ballerina-library/issues/9002
https://github.com/ballerina-platform/ballerina-library/issues/8985
https://github.com/ballerina-platform/ballerina-library/issues/8985

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added AWS S3 Express One Zone directory bucket support.
- Added APIs to create and list directory buckets and create sessions.
- Added directory bucket configuration, metadata, redundancy, session, and credential types.
- Added pagination and response handling for directory bucket operations.
- Added support for common prefixes and additional storage classes.
- Updated generated Ballerina dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->