### PR TITLE
Add generatePomFileForMavenPublication task to gradle build file

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -251,4 +251,5 @@ build.dependsOn ":aws.s3-native:build"
 test.dependsOn ":aws.s3-native:build"
 
 build.dependsOn copyToLib
+build.dependsOn "generatePomFileForMavenPublication"
 test.dependsOn copyToLib


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `ballerina/build.gradle` so the `build` task generates the Maven publication POM through `generatePomFileForMavenPublication`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->