### PR TITLE
Improve the readability of the ftp to s3 sample

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -251,4 +251,5 @@ build.dependsOn ":aws.s3-native:build"
 test.dependsOn ":aws.s3-native:build"
 
 build.dependsOn copyToLib
+build.dependsOn "generatePomFileForMavenPublication"
 test.dependsOn copyToLib

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ The `ballerinax/aws.s3` connector provides practical examples illustrating usage
 
 2. [FTP to S3 Sync](https://github.com/ballerina-platform/module-ballerinax-aws.s3/tree/master/examples/ftp-to-s3-sync)
 
-   This example shows how to sync files from an FTP server to an AWS S3 bucket. It lists files on the FTP server, skips files already present in S3, downloads new files, uploads them under a configured S3 prefix, and produces a sync summary report.
+   This example shows how to upload files from an FTP server to an AWS S3 bucket. It lists all files in a given FTP directory and uploads each one to S3.
 
 ## Prerequisites
 

--- a/examples/ftp-to-s3-sync/ftp-to-s3-sync.md
+++ b/examples/ftp-to-s3-sync/ftp-to-s3-sync.md
@@ -2,13 +2,11 @@
 
 ## Introduction
 
-This guide demonstrates how to sync files from an FTP server to an AWS S3 bucket using the Ballerina AWS S3 connector. The workflow covers listing files on the FTP server, skipping files already present in S3, downloading new files from FTP, uploading them to S3 under a configured prefix, cleaning up local temp files after each upload, and producing a full sync summary report at the end.
+This example demonstrates how to upload files from an FTP server to an AWS S3 bucket using the Ballerina AWS S3 connector. It lists all files in a given FTP directory and uploads each one to S3.
 
 ## Prerequisites
 
 Follow the guidelines in the [Setup guide](https://github.com/ballerina-platform/module-ballerinax-aws.s3#setup-guide) to obtain the necessary credentials to access the Amazon S3 API.
-
-> **Note:** The IAM user must have `s3:PutObject`, `s3:GetObject`, `s3:HeadObject`, and `s3:ListBucket` permissions on your bucket.
 
 ### Configuration
 
@@ -20,7 +18,6 @@ s3AccessKeyId     = "<ACCESS_KEY_ID>"
 s3SecretAccessKey = "<SECRET_ACCESS_KEY>"
 s3BucketName      = "<BUCKET_NAME>"
 s3Region          = "us-east-1"
-s3Prefix          = "ftp-synced"
 
 # FTP Server
 ftpHost      = "<FTP_HOST>"

--- a/examples/ftp-to-s3-sync/main.bal
+++ b/examples/ftp-to-s3-sync/main.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/file;
 import ballerina/ftp;
 import ballerina/io;
 import ballerina/log;
@@ -25,7 +24,6 @@ configurable string s3AccessKeyId = ?;
 configurable string s3SecretAccessKey = ?;
 configurable string s3BucketName = ?;
 configurable aws:Region s3Region = ?;
-configurable string s3Prefix = ?;
 
 configurable string ftpHost = ?;
 configurable int ftpPort = 21;
@@ -33,151 +31,48 @@ configurable string ftpUser = ?;
 configurable string ftpPassword = ?;
 configurable string ftpRemoteDir = "/";
 
-type SyncStats record {
-    int totalFiles;
-    int successfulUploads;
-    int failedUploads;
-    int skippedFiles;
-    string[] errors;
-};
-
-function buildS3Key(string filename) returns string {
-    return s3Prefix + "/" + filename;
-}
-
-function listFtpFiles(ftp:Client ftpClient) returns string[]|error {
-    log:printInfo(string `Listing FTP directory: ${ftpRemoteDir}`);
-
-    ftp:FileInfo[] fileList = check ftpClient->list(ftpRemoteDir);
-    string[] filenames = [];
-
-    foreach ftp:FileInfo fileInfo in fileList {
-        string fullPath = ftpRemoteDir + "/" + fileInfo.name;
-        boolean isDir = check ftpClient->isDirectory(fullPath);
-        if !isDir {
-            filenames.push(fileInfo.name);
+ftp:Client ftpClient = check new ({
+    protocol: ftp:FTP,
+    host: ftpHost,
+    port: ftpPort,
+    auth: {
+        credentials: {
+            username: ftpUser,
+            password: ftpPassword
         }
     }
+});
 
-    log:printInfo(string `Found ${filenames.length()} files`);
-    return filenames;
-}
-
-function downloadFromFtp(ftp:Client ftpClient, string filename, string localPath) returns error? {
-    string remotePath = ftpRemoteDir + "/" + filename;
-    log:printInfo(string `Downloading: ${remotePath} → ${localPath}`);
-
-    // Get file content as a stream from FTP
-    stream<byte[] & readonly, io:Error?> fileStream = check ftpClient->get(remotePath);
-
-    // Write stream to local temp file
-    error? writeErr = io:fileWriteBlocksFromStream(localPath, fileStream);
-    error? closeErr = fileStream.close();
-    check writeErr;
-    check closeErr;
-
-    log:printInfo(string `Downloaded: ${filename}`);
-}
-
-function existsInS3(s3:Client s3Client, string filename) returns boolean|error {
-    string s3Key = buildS3Key(filename);
-    return s3Client->doesObjectExist(s3BucketName, s3Key);
-}
-
-function uploadToS3(s3:Client s3Client, string localFilePath, string filename) returns error? {
-    string s3Key = buildS3Key(filename);
-    log:printInfo(string `Uploading to S3: ${s3Key}`);
-
-    byte[] fileContent = check io:fileReadBytes(localFilePath);
-    check s3Client->putObject(s3BucketName, s3Key, fileContent);
-
-    log:printInfo(string `Uploaded: ${s3Key}`);
-}
-
-function validateFilename(string filename) returns error? {
-    if string:indexOf(filename, "/") >= 0 ||
-        string:indexOf(filename, "\\") >= 0 ||
-        string:indexOf(filename, "..") >= 0 {
-        return error("Invalid FTP filename");
+s3:Client s3Client = check new ({
+    region: s3Region,
+    auth: {
+        accessKeyId: s3AccessKeyId,
+        secretAccessKey: s3SecretAccessKey
     }
-}
-
-function syncFtpToS3(ftp:Client ftpClient, s3:Client s3Client) returns SyncStats|error {
-    SyncStats stats = {
-        totalFiles: 0,
-        successfulUploads: 0,
-        failedUploads: 0,
-        skippedFiles: 0,
-        errors: []
-    };
-
-    string tempDir = "./ftp_sync_temp";
-    check file:createDir(tempDir, file:RECURSIVE);
-
-    do {
-        string[] ftpFiles = check listFtpFiles(ftpClient);
-        stats.totalFiles = ftpFiles.length();
-
-        foreach string filename in ftpFiles {
-            do {
-                // Skip if already uploaded
-                boolean exists = check existsInS3(s3Client, filename);
-                if exists {
-                    log:printInfo(string `Skipping (already in S3): ${filename}`);
-                    stats.skippedFiles += 1;
-                    continue;
-                }
-
-                check validateFilename(filename);
-                string localPath = string `${tempDir}/${filename}`;
-
-                check downloadFromFtp(ftpClient, filename, localPath);
-                check uploadToS3(s3Client, localPath, filename);
-                stats.successfulUploads += 1;
-
-                // Clean up temp file immediately after upload
-                check file:remove(localPath);
-
-            } on fail error e {
-                log:printError(string `Failed: ${filename} — ${e.message()}`, 'error = e);
-                stats.failedUploads += 1;
-                stats.errors.push(string `${filename}: ${e.message()}`);
-            }
-        }
-    } on fail error e {
-        _ = file:remove(tempDir, file:RECURSIVE);
-        return e;
-    }
-
-    // Clean up temp dir
-    check file:remove(tempDir, file:RECURSIVE);
-    return stats;
-}
+});
 
 public function main() returns error? {
+    // List files in the FTP directory
+    ftp:FileInfo[] fileList = check ftpClient->list(ftpRemoteDir);
 
-    // Initialize FTP client
-    ftp:Client ftpClient = check new ({
-        protocol: ftp:FTP,
-        host: ftpHost,
-        port: ftpPort,
-        auth: {
-            credentials: {
-                username: ftpUser,
-                password: ftpPassword
-            }
+    foreach ftp:FileInfo fileInfo in fileList {
+        string remotePath = ftpRemoteDir + "/" + fileInfo.name;
+        if check ftpClient->isDirectory(remotePath) {
+            continue;
         }
-    });
 
-    // Initialize S3 client
-    s3:Client s3Client = check new ({
-        region: s3Region,
-        auth: {
-            accessKeyId: s3AccessKeyId,
-            secretAccessKey: s3SecretAccessKey
-        }
-    });
+        // Download file content from FTP
+        stream<byte[] & readonly, io:Error?> fileStream = check ftpClient->get(remotePath);
+        byte[] content = [];
+        check fileStream.forEach(function(byte[] & readonly chunk) {
+            content.push(...chunk);
+        });
+        check fileStream.close();
 
-    _ = check syncFtpToS3(ftpClient, s3Client);
+        // Upload to S3
+        check s3Client->putObject(s3BucketName, fileInfo.name, content);
+        log:printInfo(string `Uploaded: ${fileInfo.name}`);
+    }
+
     check s3Client.close();
 }

--- a/examples/ftp-to-s3-sync/main.bal
+++ b/examples/ftp-to-s3-sync/main.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/ftp;
-import ballerina/io;
 import ballerina/log;
 import ballerinax/aws;
 import ballerinax/aws.s3;
@@ -57,20 +56,15 @@ public function main() returns error? {
 
     foreach ftp:FileInfo fileInfo in fileList {
         string remotePath = ftpRemoteDir + "/" + fileInfo.name;
-        if check ftpClient->isDirectory(remotePath) {
+        boolean isDirectory = check ftpClient->isDirectory(remotePath);
+        if isDirectory {
             continue;
         }
 
-        // Download file content from FTP
-        stream<byte[] & readonly, io:Error?> fileStream = check ftpClient->get(remotePath);
-        byte[] content = [];
-        check fileStream.forEach(function(byte[] & readonly chunk) {
-            content.push(...chunk);
-        });
-        check fileStream.close();
-
-        // Upload to S3
-        check s3Client->putObject(s3BucketName, fileInfo.name, content);
+        // Download file content from FTP and upload to S3
+        stream<byte[], error?> fileStream = check ftpClient->getBytesAsStream(remotePath);
+        check s3Client->putObjectAsStream(s3BucketName, fileInfo.name, fileStream,
+                contentLength = fileInfo.size);
         log:printInfo(string `Uploaded: ${fileInfo.name}`);
     }
 


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Simplified the FTP-to-S3 sample to upload all files from an FTP directory directly to S3.
- Streamed file content directly to S3 and removed temporary-file handling, duplicate detection, summary reporting, and unused configuration.
- Updated the guide and example description to reflect the simplified upload flow.
- Updated the Gradle build to generate the Maven publication POM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->